### PR TITLE
Add direct-to-PostgreSQL output via COPY protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,11 @@ Purpose-built Rust tool for converting Discogs XML data dumps to CSV files compa
 
 - `model.rs` -- Data structures mirroring Discogs XML `<release>` elements
 - `parser.rs` -- Pull-based XML parser using `quick-xml`, supports plain and gzipped input; `parse_release_from_bytes()` enables per-release parsing for the parallel pipeline
-- `writer.rs` -- CSV output (6 files matching `import_csv.py` contract)
+- `output.rs` -- `ReleaseOutput` trait abstracting over output targets (CSV or PostgreSQL)
+- `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` (6 CSV files matching `import_csv.py` contract)
+- `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; also contains pure transform functions ported from `import_csv.py` (extract_year, COPY TEXT escaping, artwork selection, dedup)
 - `filter.rs` -- Artist name normalization (NFKD + strip combining chars) and HashSet filtering; `ArtistFilter` is `Sync` for parallel access
-- `main.rs` -- CLI using clap derive; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer)
+- `main.rs` -- CLI using clap derive; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer); output dispatch between CSV and PG modes
 
 ### Parallel Processing Pipeline
 
@@ -20,9 +22,19 @@ Release processing uses a three-stage pipeline for multi-core parallelism:
 
 1. **Scanner thread** -- reads the input file, scans for `<release>...</release>` byte boundaries, batches raw byte ranges (256 per batch), sends via bounded channel (capacity 4)
 2. **Rayon worker pool** -- receives batches, parses XML from bytes + normalizes/filters artists in parallel using `par_iter()` (order-preserving)
-3. **Writer (main thread)** -- writes matched releases to CSV sequentially, preserving XML document order
+3. **Writer (main thread)** -- writes matched releases via `ReleaseOutput` trait, preserving XML document order
 
-Artist and label XML files are processed in parallel via `std::thread::scope` when both are present in directory mode.
+The writer stage dispatches to either `CsvOutput` (CSV files) or `PgOutput` (PostgreSQL COPY) based on the `--database-url` flag. Artist and label XML files are processed in parallel via `std::thread::scope` when both are present in directory mode.
+
+### Output Architecture
+
+The `ReleaseOutput` trait (`output.rs`) provides a common interface for writing release data:
+
+- `write_release()` -- buffer a single release and all its child records
+- `flush()` -- send buffered data to the output target
+- `finish()` -- flush remaining data and perform post-processing
+
+`CsvOutput` writes 6 CSV files to disk. `PgOutput` buffers COPY TEXT rows in memory and flushes to PostgreSQL every `--batch-size` releases, writing tables in FK order (release first, then children). `PgOutput::finish()` also handles artwork URL population, track count table creation, and cache_metadata insertion.
 
 ### CSV Output Contract
 
@@ -39,9 +51,12 @@ All code changes follow test-driven development. No production code without a fa
 ```bash
 cargo test          # all tests (unit, integration, oracle, CLI)
 cargo test --lib    # unit tests only
+
+# PostgreSQL integration tests (requires a test database)
+TEST_DATABASE_URL=postgresql:///discogs_test cargo test pg_output
 ```
 
-No external dependencies needed. All fixtures are hand-written and checked in.
+Unit tests and CSV tests use hand-written XML fixtures; no external dependencies needed. PostgreSQL integration tests are gated by the `TEST_DATABASE_URL` environment variable and skip automatically when it is not set.
 
 ### Build
 
@@ -66,3 +81,7 @@ cargo build --release   # produces target/release/discogs-xml-converter
 - The byte scanner finds `<release>` boundaries by searching for `b"<release "` (trailing space distinguishes from `<released>`) and `b"</release>"` (no suffix distinguishes from `</released>`)
 - `par_iter().map().collect()` preserves input order so CSV output is deterministic regardless of thread scheduling
 - Bounded channel (capacity 4 batches of 256 releases) provides backpressure to prevent unbounded memory growth
+- `PgOutput` replicates `import_csv.py`'s transforms in Rust: `extract_year`, empty-to-NULL, COPY TEXT escaping, dedup by unique key, artwork URL selection
+- `PgOutput` flushes tables in FK order (release first, then children) so FK constraints are satisfied within each flush
+- In direct-PG mode, all tables (including tracks) are imported in a single pass; dedup's CASCADE delete removes extra tracks afterward
+- `PgOutput::finish()` handles artwork URLs, `release_track_count` table, and `cache_metadata` -- replicating `import_csv.py --base-only` post-import work

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,16 +89,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -110,6 +136,24 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -164,6 +208,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +260,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +303,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "discogs-xml-converter"
 version = "0.1.0"
 dependencies = [
@@ -251,6 +325,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "log",
+ "postgres",
  "predicates",
  "pretty_assertions",
  "quick-xml",
@@ -305,6 +380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +417,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,7 +486,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -368,6 +511,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "id-arena"
@@ -424,6 +576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,16 +598,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -464,6 +654,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +680,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +708,60 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -503,6 +776,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -584,9 +909,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -606,6 +966,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -651,10 +1020,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -705,16 +1086,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -734,7 +1165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -762,6 +1193,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +1273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,12 +1291,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
 ]
 
 [[package]]
@@ -813,6 +1336,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -847,6 +1424,29 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]
@@ -957,6 +1557,26 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 env_logger = "0.11"
 crossbeam-channel = "0.5"
 rayon = "1.10"
+postgres = "0.19"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ discogs-xml-converter releases.xml.gz --output-dir /path/to/filtered/ \
 discogs-xml-converter releases.xml.gz --output-dir /tmp/test/ --limit 100
 ```
 
+### Direct-to-PostgreSQL mode
+
+Stream releases directly into PostgreSQL, bypassing the CSV round-trip:
+
+```bash
+# Stream releases directly into PostgreSQL
+discogs-xml-converter /path/to/xml-dumps/ \
+  --output-dir /path/to/supplementary/ \
+  --library-artists library_artists.txt \
+  --database-url postgresql://localhost:5432/discogs
+
+# With custom batch size (default: 10000)
+discogs-xml-converter releases.xml.gz \
+  --output-dir /tmp/out/ \
+  --database-url postgresql://localhost:5432/discogs \
+  --batch-size 5000
+```
+
+When `--database-url` is provided, releases are streamed into PostgreSQL via COPY instead of being written to CSV files. Supplementary CSVs (artist_alias.csv, label_hierarchy.csv) are still written to `--output-dir`.
+
 ### Options
 
 | Flag | Description |
@@ -32,6 +52,8 @@ discogs-xml-converter releases.xml.gz --output-dir /tmp/test/ --limit 100
 | `--library-artists FILE` | Filter to releases by artists in this file (one per line) |
 | `--limit N` | Stop after N releases |
 | `--progress-interval N` | Log progress every N releases (default: 100000) |
+| `--database-url URL` | Stream releases directly into PostgreSQL via COPY |
+| `--batch-size N` | Releases to buffer before flushing to PostgreSQL (default: 10000) |
 
 Gzipped input is auto-detected by `.gz` extension.
 
@@ -80,6 +102,20 @@ cargo test
 All tests use hand-written XML fixtures; no external data dumps needed.
 
 ## Integration with discogs-cache
+
+### Direct-to-PostgreSQL pipeline (recommended)
+
+Streams releases directly into PostgreSQL, eliminating the CSV round-trip:
+
+```bash
+python scripts/run_pipeline.py \
+  --xml /path/to/xml-dumps/ \
+  --library-artists library_artists.txt \
+  --database-url postgresql://localhost:5432/discogs \
+  --direct-pg
+```
+
+### CSV pipeline
 
 Feed the output into the `--csv-dir` pipeline mode:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,7 @@ pub mod label_model;
 pub mod label_parser;
 pub mod label_writer;
 pub mod model;
+pub mod output;
 pub mod parser;
+pub mod pg_output;
 pub mod writer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ use discogs_xml_converter::filter::ArtistFilter;
 use discogs_xml_converter::label_parser::parse_labels;
 use discogs_xml_converter::label_writer::LabelCsvOutput;
 use discogs_xml_converter::parser::parse_release_from_bytes;
+use discogs_xml_converter::output::ReleaseOutput;
+use discogs_xml_converter::pg_output::PgOutput;
 use discogs_xml_converter::writer::CsvOutput;
 use rayon::prelude::*;
 
@@ -46,6 +48,17 @@ struct Cli {
     /// Log progress every N releases
     #[arg(long, default_value = "100000")]
     progress_interval: usize,
+
+    /// PostgreSQL connection URL for direct-to-database output.
+    /// When provided, releases are streamed directly into PostgreSQL
+    /// via COPY instead of being written to CSV files.
+    #[arg(long)]
+    database_url: Option<String>,
+
+    /// Number of releases to buffer before flushing to PostgreSQL.
+    /// Only used with --database-url.
+    #[arg(long, default_value = "10000")]
+    batch_size: usize,
 }
 
 /// Detect the XML type by reading the root element.
@@ -184,7 +197,7 @@ enum FilterResult {
 
 fn process_releases(
     path: &Path,
-    output_dir: &Path,
+    output: &mut impl ReleaseOutput,
     filter: &Option<ArtistFilter>,
     limit: Option<usize>,
     progress_interval: usize,
@@ -202,7 +215,6 @@ fn process_releases(
         });
 
         // Main thread: receive batches, parse+filter with rayon, write matches
-        let mut csv = CsvOutput::new(output_dir)?;
         let mut written = 0usize;
         let mut filtered = 0usize;
         let mut skipped_no_artists = 0usize;
@@ -237,7 +249,7 @@ fn process_releases(
             for result in results {
                 match result {
                     FilterResult::Matched(release) => {
-                        csv.write_release(&release)?;
+                        output.write_release(&release)?;
                         written += 1;
                     }
                     FilterResult::Filtered => filtered += 1,
@@ -246,7 +258,7 @@ fn process_releases(
             }
         }
 
-        csv.flush()?;
+        output.flush()?;
         let total = scanner.join().unwrap()?;
         info!(
             "Complete: {} scanned, {} written, {} filtered, {} skipped (no artists)",
@@ -492,13 +504,27 @@ fn main() -> Result<()> {
 
         // Step 4: Process releases with (optionally enhanced) filter
         if let Some(ref releases_path) = xml_files.releases {
-            process_releases(
-                releases_path,
-                &cli.output_dir,
-                &filter,
-                cli.limit,
-                cli.progress_interval,
-            )?;
+            if let Some(ref db_url) = cli.database_url {
+                let mut output = PgOutput::new(db_url, cli.batch_size)?;
+                process_releases(
+                    releases_path,
+                    &mut output,
+                    &filter,
+                    cli.limit,
+                    cli.progress_interval,
+                )?;
+                output.finish()?;
+            } else {
+                let mut output = CsvOutput::new(&cli.output_dir)?;
+                process_releases(
+                    releases_path,
+                    &mut output,
+                    &filter,
+                    cli.limit,
+                    cli.progress_interval,
+                )?;
+                output.finish()?;
+            }
         } else {
             warn!("No releases XML found in directory {}", cli.input.display());
         }
@@ -516,13 +542,27 @@ fn main() -> Result<()> {
             None => None,
         };
 
-        process_releases(
-            &cli.input,
-            &cli.output_dir,
-            &filter,
-            cli.limit,
-            cli.progress_interval,
-        )?;
+        if let Some(ref db_url) = cli.database_url {
+            let mut output = PgOutput::new(db_url, cli.batch_size)?;
+            process_releases(
+                &cli.input,
+                &mut output,
+                &filter,
+                cli.limit,
+                cli.progress_interval,
+            )?;
+            output.finish()?;
+        } else {
+            let mut output = CsvOutput::new(&cli.output_dir)?;
+            process_releases(
+                &cli.input,
+                &mut output,
+                &filter,
+                cli.limit,
+                cli.progress_interval,
+            )?;
+            output.finish()?;
+        }
     }
 
     Ok(())

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,25 @@
+//! Output trait for release data.
+//!
+//! Defines the `ReleaseOutput` trait that abstracts over different output
+//! targets (CSV files, PostgreSQL, etc.) for the release processing pipeline.
+
+use anyhow::Result;
+
+use crate::model::Release;
+
+/// Trait for writing release data to an output target.
+///
+/// Implementations buffer writes internally. Call `finish()` after all
+/// releases have been written to flush remaining data and perform any
+/// post-processing.
+pub trait ReleaseOutput {
+    /// Write a single release and all its child records to the output.
+    fn write_release(&mut self, release: &Release) -> Result<()>;
+
+    /// Flush any buffered data to the output target.
+    fn flush(&mut self) -> Result<()>;
+
+    /// Finalize the output: flush remaining data and perform any
+    /// post-processing (e.g., artwork URL population, track count computation).
+    fn finish(&mut self) -> Result<()>;
+}

--- a/src/pg_output.rs
+++ b/src/pg_output.rs
@@ -1,0 +1,976 @@
+//! PostgreSQL direct output for release data.
+//!
+//! Provides `PgOutput`, which implements `ReleaseOutput` to stream releases
+//! directly into PostgreSQL via COPY, eliminating the CSV round-trip.
+//!
+//! Also contains pure transform functions that replicate the logic from
+//! `discogs-cache/scripts/import_csv.py`.
+
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use log::info;
+
+use crate::model::Release;
+use crate::output::ReleaseOutput;
+
+/// Extract a 4-digit year from a Discogs "released" field.
+///
+/// Matches the behavior of `import_csv.py:extract_year()`.
+pub fn extract_year(released: &str) -> Option<i16> {
+    if released.len() >= 4 && released.as_bytes()[..4].iter().all(|b| b.is_ascii_digit()) {
+        released[..4].parse().ok()
+    } else {
+        None
+    }
+}
+
+/// Convert an empty string to None.
+pub fn empty_to_none(s: &str) -> Option<&str> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+/// Escape a string for PostgreSQL COPY TEXT format.
+///
+/// COPY TEXT uses tab-delimited rows with backslash escaping:
+/// - `\` → `\\`
+/// - newline → `\n`
+/// - carriage return → `\r`
+/// - tab → `\t`
+pub fn escape_copy_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Format a value for a COPY TEXT column.
+///
+/// None values become `\N` (PostgreSQL NULL). Non-empty strings are escaped.
+fn copy_value(val: Option<&str>) -> String {
+    match val {
+        None => "\\N".to_string(),
+        Some("") => "\\N".to_string(),
+        Some(s) => escape_copy_text(s),
+    }
+}
+
+/// Format a COPY TEXT row from a slice of column values.
+///
+/// Joins values with tabs and appends a newline.
+pub fn copy_line(values: &[Option<&str>]) -> String {
+    let mut line = String::new();
+    for (i, val) in values.iter().enumerate() {
+        if i > 0 {
+            line.push('\t');
+        }
+        line.push_str(&copy_value(*val));
+    }
+    line.push('\n');
+    line
+}
+
+/// Pick the best artwork URL from a release's images.
+///
+/// Prefers the first "primary" image; falls back to the first image of any type.
+pub fn pick_artwork_url(images: &[crate::model::ReleaseImage]) -> Option<&str> {
+    let primary = images
+        .iter()
+        .find(|img| img.image_type == "primary")
+        .map(|img| img.uri.as_str());
+    primary.or_else(|| images.first().map(|img| img.uri.as_str()))
+}
+
+/// Dedup tracker for (release_id, artist_name) pairs in release_artist table.
+#[derive(Default)]
+pub struct ArtistDedup {
+    seen: HashSet<(u64, String)>,
+}
+
+impl ArtistDedup {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Returns true if this is the first occurrence (not a duplicate).
+    pub fn insert(&mut self, release_id: u64, artist_name: &str) -> bool {
+        self.seen
+            .insert((release_id, artist_name.to_string()))
+    }
+}
+
+/// Dedup tracker for (release_id, track_sequence, artist_name) in release_track_artist.
+#[derive(Default)]
+pub struct TrackArtistDedup {
+    seen: HashSet<(u64, u32, String)>,
+}
+
+impl TrackArtistDedup {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Returns true if this is the first occurrence (not a duplicate).
+    pub fn insert(&mut self, release_id: u64, track_seq: u32, artist_name: &str) -> bool {
+        self.seen
+            .insert((release_id, track_seq, artist_name.to_string()))
+    }
+}
+
+/// Dedup tracker for (release_id, label_name) pairs in release_label table.
+#[derive(Default)]
+pub struct LabelDedup {
+    seen: HashSet<(u64, String)>,
+}
+
+impl LabelDedup {
+    pub fn new() -> Self {
+        Self {
+            seen: HashSet::new(),
+        }
+    }
+
+    /// Returns true if this is the first occurrence (not a duplicate).
+    pub fn insert(&mut self, release_id: u64, label_name: &str) -> bool {
+        self.seen.insert((release_id, label_name.to_string()))
+    }
+}
+
+/// Accumulated artwork URLs for post-import UPDATE.
+pub type ArtworkMap = HashMap<u64, String>;
+
+/// Accumulated track counts for release_track_count table.
+pub type TrackCountMap = HashMap<u64, u32>;
+
+/// Streams release data directly into PostgreSQL via COPY.
+///
+/// Buffers releases in memory and periodically flushes to PostgreSQL.
+/// Within each flush, tables are written in FK order: `release` first,
+/// then child tables.
+pub struct PgOutput {
+    client: postgres::Client,
+    buf_release: Vec<u8>,
+    buf_release_artist: Vec<u8>,
+    buf_release_label: Vec<u8>,
+    buf_release_track: Vec<u8>,
+    buf_release_track_artist: Vec<u8>,
+    artist_dedup: ArtistDedup,
+    label_dedup: LabelDedup,
+    track_artist_dedup: TrackArtistDedup,
+    artwork: ArtworkMap,
+    track_counts: TrackCountMap,
+    batch_count: usize,
+    batch_size: usize,
+}
+
+impl PgOutput {
+    /// Connect to PostgreSQL and prepare for streaming release data.
+    pub fn new(database_url: &str, batch_size: usize) -> Result<Self> {
+        let client = postgres::Client::connect(database_url, postgres::NoTls)
+            .with_context(|| format!("Failed to connect to PostgreSQL at {}", database_url))?;
+        Ok(Self {
+            client,
+            buf_release: Vec::new(),
+            buf_release_artist: Vec::new(),
+            buf_release_label: Vec::new(),
+            buf_release_track: Vec::new(),
+            buf_release_track_artist: Vec::new(),
+            artist_dedup: ArtistDedup::new(),
+            label_dedup: LabelDedup::new(),
+            track_artist_dedup: TrackArtistDedup::new(),
+            artwork: HashMap::new(),
+            track_counts: HashMap::new(),
+            batch_count: 0,
+            batch_size,
+        })
+    }
+
+    /// COPY a buffer of COPY TEXT data into a table. No-op if buffer is empty.
+    fn copy_buffer(client: &mut postgres::Client, stmt: &str, buf: &[u8]) -> Result<()> {
+        if buf.is_empty() {
+            return Ok(());
+        }
+        let mut writer = client.copy_in(stmt)?;
+        writer.write_all(buf)?;
+        writer.finish()?;
+        Ok(())
+    }
+}
+
+impl ReleaseOutput for PgOutput {
+    fn write_release(&mut self, release: &Release) -> Result<()> {
+        // Skip releases with empty title (required field)
+        if release.title.is_empty() {
+            return Ok(());
+        }
+
+        let id_str = release.id.to_string();
+        let year_str = extract_year(&release.released).map(|y| y.to_string());
+        let master_id_str = release.master_id.map(|id| id.to_string());
+
+        // release row: id, title, release_year, country, master_id
+        let line = copy_line(&[
+            Some(&id_str),
+            Some(&release.title),
+            year_str.as_deref(),
+            empty_to_none(&release.country),
+            master_id_str.as_deref(),
+        ]);
+        self.buf_release.extend_from_slice(line.as_bytes());
+
+        // release_artist rows (main artists, extra=0)
+        for artist in &release.artists {
+            if artist.name.is_empty() {
+                continue;
+            }
+            if !self.artist_dedup.insert(release.id, &artist.name) {
+                continue;
+            }
+            let artist_id_str = artist.artist_id.to_string();
+            let line = copy_line(&[
+                Some(&id_str),
+                Some(&artist_id_str),
+                Some(&artist.name),
+                Some("0"),
+            ]);
+            self.buf_release_artist
+                .extend_from_slice(line.as_bytes());
+        }
+
+        // release_artist rows (extra artists, extra=1)
+        for artist in &release.extra_artists {
+            if artist.name.is_empty() {
+                continue;
+            }
+            if !self.artist_dedup.insert(release.id, &artist.name) {
+                continue;
+            }
+            let artist_id_str = artist.artist_id.to_string();
+            let line = copy_line(&[
+                Some(&id_str),
+                Some(&artist_id_str),
+                Some(&artist.name),
+                Some("1"),
+            ]);
+            self.buf_release_artist
+                .extend_from_slice(line.as_bytes());
+        }
+
+        // release_label rows (release_id, label_name only -- catno is not in the DB)
+        for label in &release.labels {
+            if label.name.is_empty() {
+                continue;
+            }
+            if !self.label_dedup.insert(release.id, &label.name) {
+                continue;
+            }
+            let line = copy_line(&[Some(&id_str), Some(&label.name)]);
+            self.buf_release_label
+                .extend_from_slice(line.as_bytes());
+        }
+
+        // release_track rows + track count
+        let track_count = release.tracks.len() as u32;
+        if track_count > 0 {
+            self.track_counts.insert(release.id, track_count);
+        }
+
+        for (idx, track) in release.tracks.iter().enumerate() {
+            // Skip tracks with empty title (required field)
+            if track.title.is_empty() {
+                continue;
+            }
+            let seq = (idx + 1) as u32;
+            let seq_str = seq.to_string();
+            let line = copy_line(&[
+                Some(&id_str),
+                Some(&seq_str),
+                empty_to_none(&track.position),
+                Some(&track.title),
+                empty_to_none(&track.duration),
+            ]);
+            self.buf_release_track
+                .extend_from_slice(line.as_bytes());
+
+            // Track artists (both main and extra)
+            for artist in track.artists.iter().chain(track.extra_artists.iter()) {
+                if !self
+                    .track_artist_dedup
+                    .insert(release.id, seq, &artist.name)
+                {
+                    continue;
+                }
+                let line =
+                    copy_line(&[Some(&id_str), Some(&seq_str), Some(&artist.name)]);
+                self.buf_release_track_artist
+                    .extend_from_slice(line.as_bytes());
+            }
+        }
+
+        // Artwork (accumulated for batch UPDATE in finish())
+        if let Some(url) = pick_artwork_url(&release.images) {
+            self.artwork.insert(release.id, url.to_string());
+        }
+
+        // Flush if batch is full
+        self.batch_count += 1;
+        if self.batch_count >= self.batch_size {
+            self.flush()?;
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        if self.batch_count == 0 {
+            return Ok(());
+        }
+
+        // FK-safe ordering: release (parent) first, then child tables
+        Self::copy_buffer(
+            &mut self.client,
+            "COPY release (id, title, release_year, country, master_id) FROM STDIN",
+            &self.buf_release,
+        )?;
+        Self::copy_buffer(
+            &mut self.client,
+            "COPY release_artist (release_id, artist_id, artist_name, extra) FROM STDIN",
+            &self.buf_release_artist,
+        )?;
+        Self::copy_buffer(
+            &mut self.client,
+            "COPY release_label (release_id, label_name) FROM STDIN",
+            &self.buf_release_label,
+        )?;
+        Self::copy_buffer(
+            &mut self.client,
+            "COPY release_track (release_id, sequence, position, title, duration) FROM STDIN",
+            &self.buf_release_track,
+        )?;
+        Self::copy_buffer(
+            &mut self.client,
+            "COPY release_track_artist (release_id, track_sequence, artist_name) FROM STDIN",
+            &self.buf_release_track_artist,
+        )?;
+
+        self.buf_release.clear();
+        self.buf_release_artist.clear();
+        self.buf_release_label.clear();
+        self.buf_release_track.clear();
+        self.buf_release_track_artist.clear();
+        self.batch_count = 0;
+
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        // 1. Flush remaining buffered rows
+        PgOutput::flush(self)?;
+
+        // 2. Artwork URL population via temp table + UPDATE JOIN
+        if !self.artwork.is_empty() {
+            info!(
+                "Updating {} releases with artwork URLs...",
+                self.artwork.len()
+            );
+            self.client.execute(
+                "CREATE TEMP TABLE _artwork (release_id integer PRIMARY KEY, artwork_url text NOT NULL)",
+                &[],
+            )?;
+
+            {
+                let mut writer = self
+                    .client
+                    .copy_in("COPY _artwork (release_id, artwork_url) FROM STDIN")?;
+                for (release_id, url) in &self.artwork {
+                    let line =
+                        copy_line(&[Some(&release_id.to_string()), Some(url)]);
+                    writer.write_all(line.as_bytes())?;
+                }
+                writer.finish()?;
+            }
+
+            self.client.execute(
+                "UPDATE release r SET artwork_url = a.artwork_url FROM _artwork a WHERE r.id = a.release_id",
+                &[],
+            )?;
+            self.client.execute("DROP TABLE _artwork", &[])?;
+        }
+
+        // 3. Track count table
+        self.client
+            .execute("DROP TABLE IF EXISTS release_track_count", &[])?;
+        self.client.execute(
+            "CREATE UNLOGGED TABLE release_track_count (release_id integer PRIMARY KEY, track_count integer NOT NULL)",
+            &[],
+        )?;
+        if !self.track_counts.is_empty() {
+            info!(
+                "Creating release_track_count with {} entries...",
+                self.track_counts.len()
+            );
+            let mut writer = self.client.copy_in(
+                "COPY release_track_count (release_id, track_count) FROM STDIN",
+            )?;
+            for (release_id, count) in &self.track_counts {
+                let line = copy_line(&[
+                    Some(&release_id.to_string()),
+                    Some(&count.to_string()),
+                ]);
+                writer.write_all(line.as_bytes())?;
+            }
+            writer.finish()?;
+        }
+
+        // 4. Cache metadata
+        self.client.execute(
+            "INSERT INTO cache_metadata (release_id, source) SELECT id, 'bulk_import' FROM release ON CONFLICT (release_id) DO NOTHING",
+            &[],
+        )?;
+
+        info!("PostgreSQL import complete");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ReleaseImage;
+
+    // -- extract_year tests --
+
+    #[test]
+    fn test_extract_year_full_date() {
+        assert_eq!(extract_year("1997-06-16"), Some(1997));
+    }
+
+    #[test]
+    fn test_extract_year_year_only() {
+        assert_eq!(extract_year("1997"), Some(1997));
+    }
+
+    #[test]
+    fn test_extract_year_malformed() {
+        assert_eq!(extract_year("Unknown"), None);
+    }
+
+    #[test]
+    fn test_extract_year_empty() {
+        assert_eq!(extract_year(""), None);
+    }
+
+    #[test]
+    fn test_extract_year_partial_digits() {
+        assert_eq!(extract_year("199"), None);
+    }
+
+    #[test]
+    fn test_extract_year_leading_zeros() {
+        assert_eq!(extract_year("0001-01-01"), Some(1));
+    }
+
+    // -- empty_to_none tests --
+
+    #[test]
+    fn test_empty_to_none_empty() {
+        assert_eq!(empty_to_none(""), None);
+    }
+
+    #[test]
+    fn test_empty_to_none_non_empty() {
+        assert_eq!(empty_to_none("hello"), Some("hello"));
+    }
+
+    // -- escape_copy_text tests --
+
+    #[test]
+    fn test_escape_copy_text_plain() {
+        assert_eq!(escape_copy_text("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_escape_copy_text_tab() {
+        assert_eq!(escape_copy_text("a\tb"), "a\\tb");
+    }
+
+    #[test]
+    fn test_escape_copy_text_newline() {
+        assert_eq!(escape_copy_text("line1\nline2"), "line1\\nline2");
+    }
+
+    #[test]
+    fn test_escape_copy_text_carriage_return() {
+        assert_eq!(escape_copy_text("a\rb"), "a\\rb");
+    }
+
+    #[test]
+    fn test_escape_copy_text_backslash() {
+        assert_eq!(escape_copy_text("path\\to\\file"), "path\\\\to\\\\file");
+    }
+
+    #[test]
+    fn test_escape_copy_text_mixed() {
+        assert_eq!(
+            escape_copy_text("line1\nline2\ttab\\slash"),
+            "line1\\nline2\\ttab\\\\slash"
+        );
+    }
+
+    // -- copy_line tests --
+
+    #[test]
+    fn test_copy_line_all_values() {
+        let line = copy_line(&[Some("1001"), Some("Test Title"), Some("US")]);
+        assert_eq!(line, "1001\tTest Title\tUS\n");
+    }
+
+    #[test]
+    fn test_copy_line_with_nulls() {
+        let line = copy_line(&[Some("1001"), None, Some("US")]);
+        assert_eq!(line, "1001\t\\N\tUS\n");
+    }
+
+    #[test]
+    fn test_copy_line_empty_string_becomes_null() {
+        let line = copy_line(&[Some("1001"), Some(""), Some("US")]);
+        assert_eq!(line, "1001\t\\N\tUS\n");
+    }
+
+    #[test]
+    fn test_copy_line_with_special_chars() {
+        let line = copy_line(&[Some("1"), Some("Title with\ttab"), Some("Note\nline2")]);
+        assert_eq!(line, "1\tTitle with\\ttab\tNote\\nline2\n");
+    }
+
+    // -- artwork tests --
+
+    #[test]
+    fn test_artwork_primary_preferred() {
+        let images = vec![
+            ReleaseImage {
+                image_type: "secondary".to_string(),
+                width: 300,
+                height: 300,
+                uri: "https://img.discogs.com/secondary.jpg".to_string(),
+            },
+            ReleaseImage {
+                image_type: "primary".to_string(),
+                width: 600,
+                height: 600,
+                uri: "https://img.discogs.com/primary.jpg".to_string(),
+            },
+        ];
+        assert_eq!(
+            pick_artwork_url(&images),
+            Some("https://img.discogs.com/primary.jpg")
+        );
+    }
+
+    #[test]
+    fn test_artwork_fallback_to_first() {
+        let images = vec![
+            ReleaseImage {
+                image_type: "secondary".to_string(),
+                width: 300,
+                height: 300,
+                uri: "https://img.discogs.com/secondary.jpg".to_string(),
+            },
+            ReleaseImage {
+                image_type: "secondary".to_string(),
+                width: 600,
+                height: 600,
+                uri: "https://img.discogs.com/another.jpg".to_string(),
+            },
+        ];
+        assert_eq!(
+            pick_artwork_url(&images),
+            Some("https://img.discogs.com/secondary.jpg")
+        );
+    }
+
+    #[test]
+    fn test_artwork_no_images() {
+        let images: Vec<ReleaseImage> = vec![];
+        assert_eq!(pick_artwork_url(&images), None);
+    }
+
+    // -- dedup tests --
+
+    #[test]
+    fn test_dedup_release_artist() {
+        let mut dedup = ArtistDedup::new();
+        assert!(dedup.insert(1001, "Autechre"));
+        assert!(dedup.insert(1001, "Boards of Canada"));
+        // Duplicate
+        assert!(!dedup.insert(1001, "Autechre"));
+        // Same artist, different release
+        assert!(dedup.insert(1002, "Autechre"));
+    }
+
+    #[test]
+    fn test_dedup_track_artist() {
+        let mut dedup = TrackArtistDedup::new();
+        assert!(dedup.insert(1001, 1, "Autechre"));
+        assert!(dedup.insert(1001, 2, "Autechre"));
+        // Duplicate
+        assert!(!dedup.insert(1001, 1, "Autechre"));
+        // Same release+track, different artist
+        assert!(dedup.insert(1001, 1, "Boards of Canada"));
+    }
+
+    #[test]
+    fn test_dedup_label() {
+        let mut dedup = LabelDedup::new();
+        assert!(dedup.insert(1001, "Warp"));
+        assert!(dedup.insert(1001, "4AD"));
+        // Duplicate
+        assert!(!dedup.insert(1001, "Warp"));
+        // Same label, different release
+        assert!(dedup.insert(1002, "Warp"));
+    }
+
+    // -- PgOutput integration tests (require TEST_DATABASE_URL) --
+
+    /// Helper to get a test DB connection, or skip the test if unavailable.
+    fn test_db_url() -> Option<String> {
+        std::env::var("TEST_DATABASE_URL").ok()
+    }
+
+    /// Set up a clean schema for testing. Drops and recreates all tables.
+    fn set_up_test_schema(client: &mut postgres::Client) {
+        // Drop tables in reverse FK order
+        client
+            .batch_execute(
+                "DROP TABLE IF EXISTS cache_metadata CASCADE;
+                 DROP TABLE IF EXISTS release_track_count CASCADE;
+                 DROP TABLE IF EXISTS release_track_artist CASCADE;
+                 DROP TABLE IF EXISTS release_track CASCADE;
+                 DROP TABLE IF EXISTS release_label CASCADE;
+                 DROP TABLE IF EXISTS release_artist CASCADE;
+                 DROP TABLE IF EXISTS release CASCADE;",
+            )
+            .unwrap();
+
+        // Create tables matching discogs-cache schema
+        client
+            .batch_execute(
+                "CREATE TABLE release (
+                    id integer PRIMARY KEY,
+                    title text NOT NULL,
+                    release_year smallint,
+                    country text,
+                    artwork_url text,
+                    master_id integer
+                );
+                CREATE TABLE release_artist (
+                    release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                    artist_id integer,
+                    artist_name text NOT NULL,
+                    extra integer DEFAULT 0
+                );
+                CREATE TABLE release_label (
+                    release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                    label_name text NOT NULL
+                );
+                CREATE TABLE release_track (
+                    release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                    sequence integer NOT NULL,
+                    position text,
+                    title text NOT NULL,
+                    duration text
+                );
+                CREATE TABLE release_track_artist (
+                    release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                    track_sequence integer NOT NULL,
+                    artist_name text NOT NULL
+                );
+                CREATE TABLE cache_metadata (
+                    release_id integer PRIMARY KEY REFERENCES release(id) ON DELETE CASCADE,
+                    cached_at timestamptz NOT NULL DEFAULT now(),
+                    source text NOT NULL,
+                    last_validated timestamptz
+                );",
+            )
+            .unwrap();
+    }
+
+    fn sample_release() -> crate::model::Release {
+        use crate::model::*;
+        Release {
+            id: 1001,
+            status: "Accepted".to_string(),
+            title: "Confield".to_string(),
+            country: "UK".to_string(),
+            released: "2001-04-30".to_string(),
+            notes: "".to_string(),
+            data_quality: "Correct".to_string(),
+            master_id: Some(500),
+            formats: vec![Format {
+                name: "CD".to_string(),
+                qty: 1,
+            }],
+            artists: vec![ReleaseArtist {
+                artist_id: 1,
+                name: "Autechre".to_string(),
+                anv: "".to_string(),
+                join_field: "".to_string(),
+                position: 1,
+            }],
+            extra_artists: vec![],
+            labels: vec![ReleaseLabel {
+                name: "Warp".to_string(),
+                catno: "WARPCD77".to_string(),
+            }],
+            tracks: vec![
+                ReleaseTrack {
+                    position: "1".to_string(),
+                    title: "VI Scose Poise".to_string(),
+                    duration: "7:36".to_string(),
+                    artists: vec![],
+                    extra_artists: vec![],
+                },
+                ReleaseTrack {
+                    position: "2".to_string(),
+                    title: "Cfern".to_string(),
+                    duration: "5:16".to_string(),
+                    artists: vec![],
+                    extra_artists: vec![],
+                },
+            ],
+            images: vec![ReleaseImage {
+                image_type: "primary".to_string(),
+                width: 600,
+                height: 600,
+                uri: "https://img.discogs.com/confield.jpg".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_pg_output_single_release() {
+        let db_url = match test_db_url() {
+            Some(url) => url,
+            None => return,
+        };
+
+        let mut setup_client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+        set_up_test_schema(&mut setup_client);
+        drop(setup_client);
+
+        let mut output = PgOutput::new(&db_url, 10000).unwrap();
+        output.write_release(&sample_release()).unwrap();
+        output.finish().unwrap();
+
+        let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+
+        // Verify release
+        let row = client
+            .query_one("SELECT id, title, release_year, country, master_id FROM release", &[])
+            .unwrap();
+        assert_eq!(row.get::<_, i32>(0), 1001);
+        assert_eq!(row.get::<_, &str>(1), "Confield");
+        assert_eq!(row.get::<_, Option<i16>>(2), Some(2001));
+        assert_eq!(row.get::<_, Option<&str>>(3), Some("UK"));
+        assert_eq!(row.get::<_, Option<i32>>(4), Some(500));
+
+        // Verify release_artist
+        let rows = client
+            .query("SELECT release_id, artist_id, artist_name, extra FROM release_artist", &[])
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get::<_, &str>(2), "Autechre");
+        assert_eq!(rows[0].get::<_, Option<i32>>(3), Some(0));
+
+        // Verify release_label
+        let rows = client
+            .query("SELECT release_id, label_name FROM release_label", &[])
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get::<_, &str>(1), "Warp");
+
+        // Verify release_track
+        let rows = client
+            .query(
+                "SELECT release_id, sequence, title FROM release_track ORDER BY sequence",
+                &[],
+            )
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get::<_, &str>(2), "VI Scose Poise");
+        assert_eq!(rows[1].get::<_, &str>(2), "Cfern");
+
+        // Verify artwork_url was set
+        let row = client
+            .query_one("SELECT artwork_url FROM release WHERE id = 1001", &[])
+            .unwrap();
+        assert_eq!(
+            row.get::<_, Option<&str>>(0),
+            Some("https://img.discogs.com/confield.jpg")
+        );
+
+        // Verify cache_metadata
+        let row = client
+            .query_one("SELECT source FROM cache_metadata WHERE release_id = 1001", &[])
+            .unwrap();
+        assert_eq!(row.get::<_, &str>(0), "bulk_import");
+
+        // Verify release_track_count
+        let row = client
+            .query_one(
+                "SELECT track_count FROM release_track_count WHERE release_id = 1001",
+                &[],
+            )
+            .unwrap();
+        assert_eq!(row.get::<_, i32>(0), 2);
+    }
+
+    #[test]
+    fn test_pg_output_batch_boundary() {
+        let db_url = match test_db_url() {
+            Some(url) => url,
+            None => return,
+        };
+
+        let mut setup_client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+        set_up_test_schema(&mut setup_client);
+        drop(setup_client);
+
+        // Use batch_size=2 to trigger a flush mid-import
+        let mut output = PgOutput::new(&db_url, 2).unwrap();
+
+        for i in 1..=5 {
+            let release = crate::model::Release {
+                id: i,
+                title: format!("Release {}", i),
+                artists: vec![crate::model::ReleaseArtist {
+                    artist_id: 1,
+                    name: "Artist".to_string(),
+                    position: 1,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            output.write_release(&release).unwrap();
+        }
+        output.finish().unwrap();
+
+        let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+        let row = client
+            .query_one("SELECT count(*) FROM release", &[])
+            .unwrap();
+        assert_eq!(row.get::<_, i64>(0), 5);
+    }
+
+    #[test]
+    fn test_pg_output_dedup() {
+        let db_url = match test_db_url() {
+            Some(url) => url,
+            None => return,
+        };
+
+        let mut setup_client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+        set_up_test_schema(&mut setup_client);
+        drop(setup_client);
+
+        let mut output = PgOutput::new(&db_url, 10000).unwrap();
+
+        // Release with duplicate artist and duplicate label
+        let release = crate::model::Release {
+            id: 1,
+            title: "Test".to_string(),
+            artists: vec![
+                crate::model::ReleaseArtist {
+                    artist_id: 1,
+                    name: "Autechre".to_string(),
+                    position: 1,
+                    ..Default::default()
+                },
+                crate::model::ReleaseArtist {
+                    artist_id: 1,
+                    name: "Autechre".to_string(),
+                    position: 2,
+                    ..Default::default()
+                },
+            ],
+            labels: vec![
+                crate::model::ReleaseLabel {
+                    name: "Warp".to_string(),
+                    catno: "A".to_string(),
+                },
+                crate::model::ReleaseLabel {
+                    name: "Warp".to_string(),
+                    catno: "B".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        output.write_release(&release).unwrap();
+        output.finish().unwrap();
+
+        let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+
+        // Only 1 artist row despite 2 in input (dedup by release_id + artist_name)
+        let row = client
+            .query_one("SELECT count(*) FROM release_artist", &[])
+            .unwrap();
+        assert_eq!(row.get::<_, i64>(0), 1);
+
+        // Only 1 label row despite 2 in input (dedup by release_id + label_name)
+        let row = client
+            .query_one("SELECT count(*) FROM release_label", &[])
+            .unwrap();
+        assert_eq!(row.get::<_, i64>(0), 1);
+    }
+
+    #[test]
+    fn test_pg_output_required_skipped() {
+        let db_url = match test_db_url() {
+            Some(url) => url,
+            None => return,
+        };
+
+        let mut setup_client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+        set_up_test_schema(&mut setup_client);
+        drop(setup_client);
+
+        let mut output = PgOutput::new(&db_url, 10000).unwrap();
+
+        // Release with empty title should be skipped
+        let release = crate::model::Release {
+            id: 1,
+            title: "".to_string(),
+            artists: vec![crate::model::ReleaseArtist {
+                artist_id: 1,
+                name: "Artist".to_string(),
+                position: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        output.write_release(&release).unwrap();
+        output.finish().unwrap();
+
+        let mut client = postgres::Client::connect(&db_url, postgres::NoTls).unwrap();
+        let row = client
+            .query_one("SELECT count(*) FROM release", &[])
+            .unwrap();
+        assert_eq!(row.get::<_, i64>(0), 0);
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use csv::Writer;
 
 use crate::model::Release;
+use crate::output::ReleaseOutput;
 
 /// Manages 6 CSV writers, one per output file.
 pub struct CsvOutput {
@@ -195,6 +196,20 @@ impl CsvOutput {
     /// Get the output directory path.
     pub fn output_dir(&self) -> &Path {
         &self.output_dir
+    }
+}
+
+impl ReleaseOutput for CsvOutput {
+    fn write_release(&mut self, release: &Release) -> Result<()> {
+        CsvOutput::write_release(self, release)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        CsvOutput::flush(self)
+    }
+
+    fn finish(&mut self) -> Result<()> {
+        self.flush()
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `--database-url` flag that streams releases directly into PostgreSQL via COPY, eliminating the ~8 GB CSV round-trip
- Extract `ReleaseOutput` trait to abstract over CSV and PG output targets
- Port `import_csv.py` transforms to Rust (extract_year, COPY TEXT escaping, dedup, artwork selection)
- `PgOutput` buffers and flushes in FK-safe order with configurable `--batch-size`
- Add `--direct-pg` flag to discogs-cache's `run_pipeline.py`

Closes #7

## Test plan

- [x] All 97 existing tests pass (unit, integration, oracle, CLI)
- [x] 24 new unit tests for transform functions (extract_year, escape_copy_text, copy_line, artwork, dedup)
- [x] 4 PG integration tests (gated by `TEST_DATABASE_URL`): single release, batch boundary, dedup, required field skip
- [x] Oracle tests verify CSV mode is byte-for-byte identical
- [x] `cargo clippy` clean
- [ ] Manual end-to-end: run converter with `--database-url` against test Postgres
- [ ] Benchmark on `funlandresearch`: full pipeline with `--direct-pg` vs CSV mode