### PR TITLE
perf: Increase default COPY batch size to 100K

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,9 @@ struct Cli {
     database_url: Option<String>,
 
     /// Number of releases to buffer before flushing to PostgreSQL.
-    /// Only used with --database-url.
-    #[arg(long, default_value = "10000")]
+    /// Only used with --database-url. Larger values reduce per-COPY overhead
+    /// but use more memory (~100 bytes/release across 5 table buffers).
+    #[arg(long, default_value = "100000")]
     batch_size: usize,
 }
 


### PR DESCRIPTION
## Summary

- Increase default `--batch-size` from 10K to 100K releases
- Reduces COPY flushes from ~620 to ~62 for a typical 6M release import
- Memory impact is modest (~50 MB across 5 byte buffers at 100K)

Closes #17. See also WXYC/discogs-cache#30 (UNLOGGED placement fix).

## Test plan

- [x] `cargo check` passes
- [x] Existing tests pass (batch_size is passed explicitly in tests, not affected by default change)