### PR TITLE
Replace local modules with wxyc-etl crate imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,12 @@ Purpose-built Rust tool for converting Discogs XML data dumps to CSV files compa
 
 ### Modules
 
-- `model.rs` -- Data structures mirroring Discogs XML `<release>` elements
+- `model.rs` -- Data structures mirroring Discogs XML `<release>` elements; implements `wxyc_etl::pg::ImageRef` for `ReleaseImage`
 - `parser.rs` -- Pull-based XML parser using `quick-xml`, supports plain and gzipped input; `parse_release_from_bytes()` enables per-release parsing for the parallel pipeline
 - `output.rs` -- `ReleaseOutput` trait abstracting over output targets (CSV or PostgreSQL)
-- `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` (6 CSV files matching `import_csv.py` contract)
-- `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; also contains pure transform functions ported from `import_csv.py` (extract_year, COPY TEXT escaping, artwork selection, dedup)
-- `filter.rs` -- Artist name normalization (NFKD + strip combining chars) and HashSet filtering; `ArtistFilter` is `Sync` for parallel access
+- `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` using `wxyc_etl::csv_writer::MultiCsvWriter` for 9 CSV files matching `import_csv.py` contract
+- `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; uses `wxyc_etl::pg::BatchCopier` for FK-ordered flush and `wxyc_etl::pg::copy` for COPY TEXT escaping; domain-specific post-import logic (artwork URLs, track counts, cache_metadata) remains local
+- `filter.rs` -- `ArtistFilter` HashSet-based artist name filtering with alias support; normalization delegates to `wxyc_etl::text::normalize_artist_name()`
 - `main.rs` -- CLI using clap derive; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer); output dispatch between CSV and PG modes
 
 ### Parallel Processing Pipeline
@@ -34,11 +34,11 @@ The `ReleaseOutput` trait (`output.rs`) provides a common interface for writing 
 - `flush()` -- send buffered data to the output target
 - `finish()` -- flush remaining data and perform post-processing
 
-`CsvOutput` writes 6 CSV files to disk. `PgOutput` buffers COPY TEXT rows in memory and flushes to PostgreSQL every `--batch-size` releases, writing tables in FK order (release first, then children). `PgOutput::finish()` also handles artwork URL population, track count table creation, and cache_metadata insertion.
+`CsvOutput` writes 9 CSV files to disk via `wxyc_etl::csv_writer::MultiCsvWriter`. `PgOutput` uses `wxyc_etl::pg::BatchCopier` to buffer COPY TEXT rows in memory and flush to PostgreSQL every `--batch-size` releases, writing tables in FK order (release first, then children). `PgOutput::finish()` also handles artwork URL population, track count table creation, and cache_metadata insertion.
 
 ### CSV Output Contract
 
-The 6 output CSV files must be compatible with `discogs-cache/scripts/import_csv.py`. Headers and column order are defined in `writer.rs`. Changes to the CSV schema require coordinating with discogs-cache.
+The 9 output CSV files must be compatible with `discogs-cache/scripts/import_csv.py`. Headers and column order are defined in `writer.rs`. Changes to the CSV schema require coordinating with discogs-cache.
 
 ## Development
 
@@ -72,7 +72,7 @@ cargo build --release   # produces target/release/discogs-xml-converter
 
 ## Key Design Decisions
 
-- Artist normalization (`filter.rs:normalize_artist`) must exactly match `discogs-cache/scripts/filter_csv.py:normalize_artist()` -- NFKD decomposition, strip combining characters, lowercase, trim
+- Artist normalization delegates to `wxyc_etl::text::normalize_artist_name()`, the shared implementation that all WXYC ETL repos use for normalization parity. Parity tests in `filter.rs` verify equivalence.
 - Releases with no `<artists>` are skipped (not written to any CSV)
 - Format string: single format uses name; qty > 1 prefixes with `{qty}x`; multiple formats are comma-separated
 - Track sequence is 1-indexed position in the `<tracklist>`
@@ -82,7 +82,6 @@ cargo build --release   # produces target/release/discogs-xml-converter
 - `par_iter().map().collect()` preserves input order so CSV output is deterministic regardless of thread scheduling
 - Bounded channel (capacity 64 batches of 256 releases) provides backpressure to prevent unbounded memory growth
 - In directory mode, `start_scanner()` launches the scanner via `std::thread::spawn` before artist/label processing; `consume_releases()` joins it after the filter is ready. Uses `PathBuf` (not `&Path`) for the `'static` lifetime requirement
-- `PgOutput` replicates `import_csv.py`'s transforms in Rust: `extract_year`, empty-to-NULL, COPY TEXT escaping, dedup by unique key, artwork URL selection
-- `PgOutput` flushes tables in FK order (release first, then children) so FK constraints are satisfied within each flush
+- `PgOutput` uses `wxyc_etl::pg` for COPY TEXT escaping, `extract_year`, `pick_artwork_url`, dedup by unique key, and FK-ordered batch flush via `BatchCopier`
 - In direct-PG mode, all tables (including tracks) are imported in a single pass; dedup's CASCADE delete removes extra tracks afterward
 - `PgOutput::finish()` handles artwork URLs, `release_track_count` table, and `cache_metadata` -- replicating `import_csv.py --base-only` post-import work

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,6 +1674,7 @@ dependencies = [
 [[package]]
 name = "wxyc-etl"
 version = "0.1.0"
+source = "git+https://github.com/WXYC/wxyc-etl.git?branch=etl-unification%2F3a-combined-deps#39d005783d136ceef095cbf3115c8ecc3bfab645"
 dependencies = [
  "anyhow",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +166,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -334,6 +356,7 @@ dependencies = [
  "rayon",
  "tempfile",
  "unicode-normalization",
+ "wxyc-etl",
 ]
 
 [[package]]
@@ -388,10 +411,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -495,6 +536,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -507,6 +557,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -609,6 +668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +714,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -766,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
 dependencies = [
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-util",
  "log",
  "tokio",
@@ -803,7 +888,7 @@ dependencies = [
  "base64",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "hmac",
  "md-5",
  "memchr",
@@ -819,7 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
 dependencies = [
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
 
@@ -1009,6 +1094,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1097,6 +1197,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -1217,7 +1323,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-channel",
  "futures-util",
  "log",
@@ -1287,10 +1393,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1552,6 +1670,28 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wxyc-etl"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "crossbeam-channel",
+ "csv",
+ "env_logger",
+ "itoa",
+ "log",
+ "memchr",
+ "memmap2",
+ "postgres",
+ "rayon",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "strsim",
+ "unicode-normalization",
+ "unicode_categories",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,6 @@ dependencies = [
  "quick-xml",
  "rayon",
  "tempfile",
- "unicode-normalization",
  "wxyc-etl",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ memchr = "2"
 rayon = "1.10"
 postgres = "0.19"
 itoa = "1"
+wxyc-etl = { path = "../3a-wxyc-etl-combined/wxyc-etl" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ memchr = "2"
 rayon = "1.10"
 postgres = "0.19"
 itoa = "1"
-wxyc-etl = { path = "../3a-wxyc-etl-combined/wxyc-etl" }
+wxyc-etl = { git = "https://github.com/WXYC/wxyc-etl.git", branch = "etl-unification/3a-combined-deps", package = "wxyc-etl" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ quick-xml = "0.37"
 csv = "1.3"
 flate2 = "1.0"
 clap = { version = "4", features = ["derive"] }
-unicode-normalization = "0.1"
 anyhow = "1"
 log = "0.4"
 env_logger = "0.11"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -263,7 +263,14 @@ mod tests {
 
         #[test]
         fn parity_diacritics() {
-            let cases = ["Björk", "Sigur Rós", "Motörhead", "Hüsker Dü", "Café Tacvba", "Zoé"];
+            let cases = [
+                "Björk",
+                "Sigur Rós",
+                "Motörhead",
+                "Hüsker Dü",
+                "Café Tacvba",
+                "Zoé",
+            ];
             for name in cases {
                 assert_eq!(
                     normalize_artist(name),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,104 +1,19 @@
 //! Artist name normalization and filtering.
 //!
-//! Normalizes artist names using NFKD decomposition with combining character
-//! removal, matching the behavior of `filter_csv.py:normalize_artist()` in
-//! the discogs-cache repo.
+//! Normalizes artist names by delegating to `wxyc_etl::text::normalize_artist_name()`,
+//! which applies NFKD decomposition, strips combining characters (diacritics),
+//! lowercases, and trims whitespace.
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
-use unicode_normalization::UnicodeNormalization;
-
 /// Normalize an artist name for matching.
 ///
-/// Applies NFKD decomposition, strips combining characters (diacritics),
-/// lowercases, and trims whitespace. This matches the Python implementation:
-///
-/// ```python
-/// nfkd = unicodedata.normalize("NFKD", name)
-/// stripped = "".join(c for c in nfkd if not unicodedata.combining(c))
-/// return stripped.lower().strip()
-/// ```
+/// Delegates to [`wxyc_etl::text::normalize_artist_name()`], the shared
+/// implementation that all WXYC ETL repos use for normalization parity.
 pub fn normalize_artist(name: &str) -> String {
-    // Single-pass: NFKD decompose, skip combining chars, lowercase, collect.
-    // This reduces from 3 allocations (collect + to_lowercase + trim/to_string)
-    // to 1 (or 2 if the result needs trimming).
-    let mut result = String::with_capacity(name.len());
-    for c in name.nfkd() {
-        if !is_combining(c) {
-            for lc in c.to_lowercase() {
-                result.push(lc);
-            }
-        }
-    }
-    let trimmed = result.trim_matches(' ');
-    if trimmed.len() == result.len() {
-        result
-    } else {
-        trimmed.to_string()
-    }
-}
-
-/// Check if a character is a Unicode combining character (category M).
-fn is_combining(c: char) -> bool {
-    // Combining characters are in the Unicode General Category "M"
-    // (Mark). We check the three subcategories:
-    // - Mn (Nonspacing_Mark)
-    // - Mc (Spacing_Mark)
-    // - Me (Enclosing_Mark)
-    //
-    // The ranges cover all combining marks in BMP which is sufficient
-    // for Discogs data.
-    matches!(
-        unicode_general_category(c),
-        GeneralCategory::Mn | GeneralCategory::Mc | GeneralCategory::Me
-    )
-}
-
-#[derive(PartialEq)]
-enum GeneralCategory {
-    Mn,
-    Mc,
-    Me,
-    Other,
-}
-
-fn unicode_general_category(c: char) -> GeneralCategory {
-    // Use the char's Unicode properties. Combining characters
-    // are in these ranges. We use a simple heuristic based on
-    // Unicode block ranges for the Combining Diacritical Marks.
-    let cp = c as u32;
-
-    // Check standard combining character ranges
-    if (0x0300..=0x036F).contains(&cp)       // Combining Diacritical Marks
-        || (0x1AB0..=0x1AFF).contains(&cp)   // Combining Diacritical Marks Extended
-        || (0x1DC0..=0x1DFF).contains(&cp)   // Combining Diacritical Marks Supplement
-        || (0x20D0..=0x20FF).contains(&cp)   // Combining Diacritical Marks for Symbols
-        || (0xFE20..=0xFE2F).contains(&cp)
-    // Combining Half Marks
-    {
-        return GeneralCategory::Mn;
-    }
-
-    // Spacing combining marks (Mc) - common South Asian scripts
-    if (0x0903..=0x0903).contains(&cp)
-        || (0x093B..=0x093B).contains(&cp)
-        || (0x093E..=0x0940).contains(&cp)
-        || (0x0949..=0x094C).contains(&cp)
-    {
-        return GeneralCategory::Mc;
-    }
-
-    // Enclosing marks (Me)
-    if (0x0488..=0x0489).contains(&cp)
-        || (0x20DD..=0x20E0).contains(&cp)
-        || (0x20E2..=0x20E4).contains(&cp)
-    {
-        return GeneralCategory::Me;
-    }
-
-    GeneralCategory::Other
+    wxyc_etl::text::normalize_artist_name(name)
 }
 
 /// Artist filter backed by a normalized HashSet, with optional alias support.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -339,6 +339,90 @@ mod tests {
         // Our implementation trims only ASCII space, matching the common case
     }
 
+    /// Verify that the local normalize_artist() produces identical output to
+    /// wxyc_etl::text::normalize_artist_name() for a comprehensive set of edge cases.
+    /// This confirms the migration to the shared crate is safe.
+    mod normalization_parity_tests {
+        use super::*;
+        use wxyc_etl::text::normalize_artist_name;
+
+        #[test]
+        fn parity_diacritics() {
+            let cases = ["Björk", "Sigur Rós", "Motörhead", "Hüsker Dü", "Café Tacvba", "Zoé"];
+            for name in cases {
+                assert_eq!(
+                    normalize_artist(name),
+                    normalize_artist_name(name),
+                    "Mismatch for: {name}"
+                );
+            }
+        }
+
+        #[test]
+        fn parity_combining_characters() {
+            let cases = ["Caf\u{0301}", "nu\u{0303}ez", "Bjo\u{0308}rk"];
+            for name in cases {
+                assert_eq!(
+                    normalize_artist(name),
+                    normalize_artist_name(name),
+                    "Mismatch for: {name}"
+                );
+            }
+        }
+
+        #[test]
+        fn parity_whitespace() {
+            let cases = ["  Radiohead  ", "  Björk", "Zoé  ", "  Mixed Case  "];
+            for name in cases {
+                assert_eq!(
+                    normalize_artist(name),
+                    normalize_artist_name(name),
+                    "Mismatch for: {name}"
+                );
+            }
+        }
+
+        #[test]
+        fn parity_case() {
+            let cases = ["RADIOHEAD", "radiohead", "Radiohead", "rAdIoHeAd"];
+            for name in cases {
+                assert_eq!(
+                    normalize_artist(name),
+                    normalize_artist_name(name),
+                    "Mismatch for: {name}"
+                );
+            }
+        }
+
+        #[test]
+        fn parity_empty() {
+            assert_eq!(normalize_artist(""), normalize_artist_name(""));
+        }
+
+        #[test]
+        fn parity_wxyc_artists() {
+            let cases = [
+                "Autechre",
+                "Prince Jammy",
+                "Juana Molina",
+                "Stereolab",
+                "Cat Power",
+                "Jessica Pratt",
+                "Chuquimamani-Condori",
+                "Duke Ellington & John Coltrane",
+                "Sessa",
+                "Anne Gillis",
+            ];
+            for name in cases {
+                assert_eq!(
+                    normalize_artist(name),
+                    normalize_artist_name(name),
+                    "Mismatch for: {name}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_matches_any_with_ids_canonical_name_still_works() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/model.rs
+++ b/src/model.rs
@@ -90,6 +90,15 @@ pub struct ReleaseImage {
     pub uri: String,
 }
 
+impl wxyc_etl::pg::ImageRef for ReleaseImage {
+    fn image_type(&self) -> &str {
+        &self.image_type
+    }
+    fn uri(&self) -> &str {
+        &self.uri
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ReleaseCompany {
     pub company_id: u64,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -438,8 +438,7 @@ fn parse_release_body<R: BufRead>(
                     }
                     b"id" => {
                         if in_companies && in_company {
-                            current_company.company_id =
-                                current_text.trim().parse().unwrap_or(0);
+                            current_company.company_id = current_text.trim().parse().unwrap_or(0);
                         } else if in_track_artists || in_track_extraartists {
                             // Track artist ID - we don't use it
                         } else if in_artists || in_extraartists {
@@ -478,8 +477,7 @@ fn parse_release_body<R: BufRead>(
                     }
                     b"entity_type" => {
                         if in_companies && in_company {
-                            current_company.entity_type =
-                                current_text.trim().parse().unwrap_or(0);
+                            current_company.entity_type = current_text.trim().parse().unwrap_or(0);
                         }
                     }
                     b"company" => {
@@ -595,7 +593,10 @@ mod tests {
         assert_eq!(r.genres, vec!["Electronic", "Rock"]);
 
         // Styles
-        assert_eq!(r.styles, vec!["Alternative Rock", "Art Rock", "Experimental"]);
+        assert_eq!(
+            r.styles,
+            vec!["Alternative Rock", "Art Rock", "Experimental"]
+        );
 
         // Companies
         assert_eq!(r.companies.len(), 2);

--- a/src/pg_output.rs
+++ b/src/pg_output.rs
@@ -3,195 +3,22 @@
 //! Provides `PgOutput`, which implements `ReleaseOutput` to stream releases
 //! directly into PostgreSQL via COPY, eliminating the CSV round-trip.
 //!
-//! Also contains pure transform functions that replicate the logic from
-//! `discogs-cache/scripts/import_csv.py`.
+//! COPY TEXT escaping, batch buffering, deduplication, and helper functions
+//! are provided by the `wxyc-etl` crate. Domain-specific transforms (artwork
+//! URL population, track count table, cache_metadata insertion) remain local.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::io::Write;
 
 use anyhow::{Context, Result};
-use itoa;
 use log::info;
+use wxyc_etl::pg::{
+    escape_copy_text_into, extract_year, pick_artwork_url, write_copy_int, ArtistDedup,
+    BatchCopier, LabelDedup, TrackArtistDedup,
+};
 
 use crate::model::Release;
 use crate::output::ReleaseOutput;
-
-/// Extract a 4-digit year from a Discogs "released" field.
-///
-/// Matches the behavior of `import_csv.py:extract_year()`.
-pub fn extract_year(released: &str) -> Option<i16> {
-    if released.len() >= 4 && released.as_bytes()[..4].iter().all(|b| b.is_ascii_digit()) {
-        released[..4].parse().ok()
-    } else {
-        None
-    }
-}
-
-/// Convert an empty string to None.
-pub fn empty_to_none(s: &str) -> Option<&str> {
-    if s.is_empty() {
-        None
-    } else {
-        Some(s)
-    }
-}
-
-/// Escape a string for PostgreSQL COPY TEXT format.
-///
-/// COPY TEXT uses tab-delimited rows with backslash escaping:
-/// - `\` → `\\`
-/// - newline → `\n`
-/// - carriage return → `\r`
-/// - tab → `\t`
-pub fn escape_copy_text(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            _ => out.push(c),
-        }
-    }
-    out
-}
-
-/// Format a value for a COPY TEXT column.
-///
-/// None values become `\N` (PostgreSQL NULL). Non-empty strings are escaped.
-fn copy_value(val: Option<&str>) -> String {
-    match val {
-        None => "\\N".to_string(),
-        Some("") => "\\N".to_string(),
-        Some(s) => escape_copy_text(s),
-    }
-}
-
-/// Format a COPY TEXT row from a slice of column values.
-///
-/// Joins values with tabs and appends a newline.
-pub fn copy_line(values: &[Option<&str>]) -> String {
-    let mut line = String::new();
-    for (i, val) in values.iter().enumerate() {
-        if i > 0 {
-            line.push('\t');
-        }
-        line.push_str(&copy_value(*val));
-    }
-    line.push('\n');
-    line
-}
-
-/// Escape a string for PostgreSQL COPY TEXT format, appending directly to a byte buffer.
-///
-/// This is the zero-allocation counterpart of `escape_copy_text()`. Instead of
-/// returning a new `String`, it pushes escaped bytes directly into `buf`.
-pub fn escape_copy_text_into(buf: &mut Vec<u8>, s: &str) {
-    for &b in s.as_bytes() {
-        match b {
-            b'\\' => buf.extend_from_slice(b"\\\\"),
-            b'\n' => buf.extend_from_slice(b"\\n"),
-            b'\r' => buf.extend_from_slice(b"\\r"),
-            b'\t' => buf.extend_from_slice(b"\\t"),
-            _ => buf.push(b),
-        }
-    }
-}
-
-/// Write a COPY TEXT row directly into a byte buffer.
-///
-/// This is the zero-allocation counterpart of `copy_line()`. Values are
-/// tab-separated; `None` and empty strings become `\N` (PostgreSQL NULL).
-pub fn write_copy_row(buf: &mut Vec<u8>, values: &[Option<&str>]) {
-    for (i, val) in values.iter().enumerate() {
-        if i > 0 {
-            buf.push(b'\t');
-        }
-        match val {
-            None | Some("") => buf.extend_from_slice(b"\\N"),
-            Some(s) => escape_copy_text_into(buf, s),
-        }
-    }
-    buf.push(b'\n');
-}
-
-/// Write an integer as a COPY TEXT column value directly into a byte buffer.
-///
-/// Uses `itoa` for zero-allocation integer formatting.
-fn write_copy_int(buf: &mut Vec<u8>, n: impl itoa::Integer) {
-    let mut itoa_buf = itoa::Buffer::new();
-    buf.extend_from_slice(itoa_buf.format(n).as_bytes());
-}
-
-/// Pick the best artwork URL from a release's images.
-///
-/// Prefers the first "primary" image; falls back to the first image of any type.
-pub fn pick_artwork_url(images: &[crate::model::ReleaseImage]) -> Option<&str> {
-    let primary = images
-        .iter()
-        .find(|img| img.image_type == "primary")
-        .map(|img| img.uri.as_str());
-    primary.or_else(|| images.first().map(|img| img.uri.as_str()))
-}
-
-/// Dedup tracker for (release_id, artist_name) pairs in release_artist table.
-#[derive(Default)]
-pub struct ArtistDedup {
-    seen: HashSet<(u64, String)>,
-}
-
-impl ArtistDedup {
-    pub fn new() -> Self {
-        Self {
-            seen: HashSet::new(),
-        }
-    }
-
-    /// Returns true if this is the first occurrence (not a duplicate).
-    pub fn insert(&mut self, release_id: u64, artist_name: &str) -> bool {
-        self.seen.insert((release_id, artist_name.to_string()))
-    }
-}
-
-/// Dedup tracker for (release_id, track_sequence, artist_name) in release_track_artist.
-#[derive(Default)]
-pub struct TrackArtistDedup {
-    seen: HashSet<(u64, u32, String)>,
-}
-
-impl TrackArtistDedup {
-    pub fn new() -> Self {
-        Self {
-            seen: HashSet::new(),
-        }
-    }
-
-    /// Returns true if this is the first occurrence (not a duplicate).
-    pub fn insert(&mut self, release_id: u64, track_seq: u32, artist_name: &str) -> bool {
-        self.seen
-            .insert((release_id, track_seq, artist_name.to_string()))
-    }
-}
-
-/// Dedup tracker for (release_id, label_name) pairs in release_label table.
-#[derive(Default)]
-pub struct LabelDedup {
-    seen: HashSet<(u64, String)>,
-}
-
-impl LabelDedup {
-    pub fn new() -> Self {
-        Self {
-            seen: HashSet::new(),
-        }
-    }
-
-    /// Returns true if this is the first occurrence (not a duplicate).
-    pub fn insert(&mut self, release_id: u64, label_name: &str) -> bool {
-        self.seen.insert((release_id, label_name.to_string()))
-    }
-}
 
 /// Accumulated artwork URLs for post-import UPDATE.
 pub type ArtworkMap = HashMap<u64, String>;
@@ -206,22 +33,12 @@ pub type TrackCountMap = HashMap<u64, u32>;
 /// then child tables.
 pub struct PgOutput {
     client: postgres::Client,
-    buf_release: Vec<u8>,
-    buf_release_artist: Vec<u8>,
-    buf_release_label: Vec<u8>,
-    buf_release_track: Vec<u8>,
-    buf_release_track_artist: Vec<u8>,
-    buf_release_genre: Vec<u8>,
-    buf_release_style: Vec<u8>,
-    buf_release_company: Vec<u8>,
+    copier: BatchCopier,
     artist_dedup: ArtistDedup,
     label_dedup: LabelDedup,
     track_artist_dedup: TrackArtistDedup,
     artwork: ArtworkMap,
     track_counts: TrackCountMap,
-    batch_count: usize,
-    batch_size: usize,
-    total_written: usize,
 }
 
 impl PgOutput {
@@ -229,41 +46,59 @@ impl PgOutput {
     pub fn new(database_url: &str, batch_size: usize) -> Result<Self> {
         let client = postgres::Client::connect(database_url, postgres::NoTls)
             .with_context(|| format!("Failed to connect to PostgreSQL at {}", database_url))?;
+
+        let copier = BatchCopier::new(
+            &[
+                (
+                    "release",
+                    "COPY release (id, title, release_year, country, master_id) FROM STDIN",
+                ),
+                (
+                    "release_artist",
+                    "COPY release_artist (release_id, artist_id, artist_name, extra) FROM STDIN",
+                ),
+                (
+                    "release_label",
+                    "COPY release_label (release_id, label_name) FROM STDIN",
+                ),
+                (
+                    "release_track",
+                    "COPY release_track (release_id, sequence, position, title, duration) FROM STDIN",
+                ),
+                (
+                    "release_track_artist",
+                    "COPY release_track_artist (release_id, track_sequence, artist_name) FROM STDIN",
+                ),
+                (
+                    "release_genre",
+                    "COPY release_genre (release_id, genre) FROM STDIN",
+                ),
+                (
+                    "release_style",
+                    "COPY release_style (release_id, style) FROM STDIN",
+                ),
+                (
+                    "release_company",
+                    "COPY release_company (release_id, company_id, company_name, entity_type, entity_type_name) FROM STDIN",
+                ),
+            ],
+            batch_size,
+        );
+
         Ok(Self {
             client,
-            buf_release: Vec::new(),
-            buf_release_artist: Vec::new(),
-            buf_release_label: Vec::new(),
-            buf_release_track: Vec::new(),
-            buf_release_track_artist: Vec::new(),
-            buf_release_genre: Vec::new(),
-            buf_release_style: Vec::new(),
-            buf_release_company: Vec::new(),
+            copier,
             artist_dedup: ArtistDedup::new(),
             label_dedup: LabelDedup::new(),
             track_artist_dedup: TrackArtistDedup::new(),
             artwork: HashMap::new(),
             track_counts: HashMap::new(),
-            batch_count: 0,
-            batch_size,
-            total_written: 0,
         })
     }
 
     /// Number of releases flushed to PostgreSQL so far.
     pub fn total_written(&self) -> usize {
-        self.total_written
-    }
-
-    /// COPY a buffer of COPY TEXT data into a table. No-op if buffer is empty.
-    fn copy_buffer(client: &mut postgres::Client, stmt: &str, buf: &[u8]) -> Result<()> {
-        if buf.is_empty() {
-            return Ok(());
-        }
-        let mut writer = client.copy_in(stmt)?;
-        writer.write_all(buf)?;
-        writer.finish()?;
-        Ok(())
+        self.copier.total_written()
     }
 }
 
@@ -276,7 +111,7 @@ impl ReleaseOutput for PgOutput {
 
         // release row: id, title, release_year, country, master_id
         {
-            let buf = &mut self.buf_release;
+            let buf = self.copier.buffer("release");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             escape_copy_text_into(buf, &release.title);
@@ -304,10 +139,13 @@ impl ReleaseOutput for PgOutput {
             if artist.name.is_empty() {
                 continue;
             }
-            if !self.artist_dedup.insert(release.id, &artist.name) {
+            if !self
+                .artist_dedup
+                .insert((release.id, artist.name.to_string()))
+            {
                 continue;
             }
-            let buf = &mut self.buf_release_artist;
+            let buf = self.copier.buffer("release_artist");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             write_copy_int(buf, artist.artist_id);
@@ -321,10 +159,13 @@ impl ReleaseOutput for PgOutput {
             if artist.name.is_empty() {
                 continue;
             }
-            if !self.artist_dedup.insert(release.id, &artist.name) {
+            if !self
+                .artist_dedup
+                .insert((release.id, artist.name.to_string()))
+            {
                 continue;
             }
-            let buf = &mut self.buf_release_artist;
+            let buf = self.copier.buffer("release_artist");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             write_copy_int(buf, artist.artist_id);
@@ -338,10 +179,13 @@ impl ReleaseOutput for PgOutput {
             if label.name.is_empty() {
                 continue;
             }
-            if !self.label_dedup.insert(release.id, &label.name) {
+            if !self
+                .label_dedup
+                .insert((release.id, label.name.to_string()))
+            {
                 continue;
             }
-            let buf = &mut self.buf_release_label;
+            let buf = self.copier.buffer("release_label");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             escape_copy_text_into(buf, &label.name);
@@ -363,7 +207,7 @@ impl ReleaseOutput for PgOutput {
 
             // Write track row directly
             {
-                let buf = &mut self.buf_release_track;
+                let buf = self.copier.buffer("release_track");
                 write_copy_int(buf, release.id);
                 buf.push(b'\t');
                 write_copy_int(buf, seq);
@@ -388,11 +232,11 @@ impl ReleaseOutput for PgOutput {
             for artist in track.artists.iter().chain(track.extra_artists.iter()) {
                 if !self
                     .track_artist_dedup
-                    .insert(release.id, seq, &artist.name)
+                    .insert((release.id, seq, artist.name.to_string()))
                 {
                     continue;
                 }
-                let buf = &mut self.buf_release_track_artist;
+                let buf = self.copier.buffer("release_track_artist");
                 write_copy_int(buf, release.id);
                 buf.push(b'\t');
                 write_copy_int(buf, seq);
@@ -407,7 +251,7 @@ impl ReleaseOutput for PgOutput {
             if genre.is_empty() {
                 continue;
             }
-            let buf = &mut self.buf_release_genre;
+            let buf = self.copier.buffer("release_genre");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             escape_copy_text_into(buf, genre);
@@ -419,7 +263,7 @@ impl ReleaseOutput for PgOutput {
             if style.is_empty() {
                 continue;
             }
-            let buf = &mut self.buf_release_style;
+            let buf = self.copier.buffer("release_style");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             escape_copy_text_into(buf, style);
@@ -431,7 +275,7 @@ impl ReleaseOutput for PgOutput {
             if company.name.is_empty() {
                 continue;
             }
-            let buf = &mut self.buf_release_company;
+            let buf = self.copier.buffer("release_company");
             write_copy_int(buf, release.id);
             buf.push(b'\t');
             write_copy_int(buf, company.company_id);
@@ -450,83 +294,18 @@ impl ReleaseOutput for PgOutput {
         }
 
         // Flush if batch is full
-        self.batch_count += 1;
-        if self.batch_count >= self.batch_size {
-            self.flush()?;
-        }
+        self.copier.count_and_maybe_flush(&mut self.client)?;
 
         Ok(())
     }
 
     fn flush(&mut self) -> Result<()> {
-        if self.batch_count == 0 {
-            return Ok(());
-        }
-
-        // FK-safe ordering: release (parent) first, then child tables
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release (id, title, release_year, country, master_id) FROM STDIN",
-            &self.buf_release,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_artist (release_id, artist_id, artist_name, extra) FROM STDIN",
-            &self.buf_release_artist,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_label (release_id, label_name) FROM STDIN",
-            &self.buf_release_label,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_track (release_id, sequence, position, title, duration) FROM STDIN",
-            &self.buf_release_track,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_track_artist (release_id, track_sequence, artist_name) FROM STDIN",
-            &self.buf_release_track_artist,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_genre (release_id, genre) FROM STDIN",
-            &self.buf_release_genre,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_style (release_id, style) FROM STDIN",
-            &self.buf_release_style,
-        )?;
-        Self::copy_buffer(
-            &mut self.client,
-            "COPY release_company (release_id, company_id, company_name, entity_type, entity_type_name) FROM STDIN",
-            &self.buf_release_company,
-        )?;
-
-        self.total_written += self.batch_count;
-        info!(
-            "Flushed {} releases to PostgreSQL ({} total)",
-            self.batch_count, self.total_written
-        );
-
-        self.buf_release.clear();
-        self.buf_release_artist.clear();
-        self.buf_release_label.clear();
-        self.buf_release_track.clear();
-        self.buf_release_track_artist.clear();
-        self.buf_release_genre.clear();
-        self.buf_release_style.clear();
-        self.buf_release_company.clear();
-        self.batch_count = 0;
-
-        Ok(())
+        self.copier.flush(&mut self.client)
     }
 
     fn finish(&mut self) -> Result<()> {
         // 1. Flush remaining buffered rows
-        PgOutput::flush(self)?;
+        self.copier.flush(&mut self.client)?;
 
         // 2. Artwork URL population via temp table + UPDATE JOIN
         if !self.artwork.is_empty() {
@@ -602,10 +381,9 @@ impl ReleaseOutput for PgOutput {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::model::ReleaseImage;
+    use wxyc_etl::pg::{copy_line, empty_to_none, escape_copy_text, write_copy_row};
 
-    // -- extract_year tests --
+    // -- extract_year tests (now delegating to wxyc_etl) --
 
     #[test]
     fn test_extract_year_full_date() {
@@ -715,14 +493,14 @@ mod tests {
     #[test]
     fn test_escape_copy_text_into_plain() {
         let mut buf = Vec::new();
-        escape_copy_text_into(&mut buf, "hello world");
+        wxyc_etl::pg::escape_copy_text_into(&mut buf, "hello world");
         assert_eq!(buf, b"hello world");
     }
 
     #[test]
     fn test_escape_copy_text_into_special_chars() {
         let mut buf = Vec::new();
-        escape_copy_text_into(&mut buf, "line1\nline2\ttab\\slash\rret");
+        wxyc_etl::pg::escape_copy_text_into(&mut buf, "line1\nline2\ttab\\slash\rret");
         assert_eq!(buf, b"line1\\nline2\\ttab\\\\slash\\rret");
     }
 
@@ -731,7 +509,7 @@ mod tests {
         let cases = ["hello", "a\tb", "a\nb", "a\\b", "a\rb", "mix\t\n\\end"];
         for s in &cases {
             let mut buf = Vec::new();
-            escape_copy_text_into(&mut buf, s);
+            wxyc_etl::pg::escape_copy_text_into(&mut buf, s);
             assert_eq!(
                 String::from_utf8(buf).unwrap(),
                 escape_copy_text(s),
@@ -800,25 +578,28 @@ mod tests {
     #[test]
     fn test_write_copy_int_u64() {
         let mut buf = Vec::new();
-        write_copy_int(&mut buf, 12345u64);
+        wxyc_etl::pg::write_copy_int(&mut buf, 12345u64);
         assert_eq!(buf, b"12345");
     }
 
     #[test]
     fn test_write_copy_int_i16() {
         let mut buf = Vec::new();
-        write_copy_int(&mut buf, 2001i16);
+        wxyc_etl::pg::write_copy_int(&mut buf, 2001i16);
         assert_eq!(buf, b"2001");
     }
 
     #[test]
     fn test_write_copy_int_u32() {
         let mut buf = Vec::new();
-        write_copy_int(&mut buf, 0u32);
+        wxyc_etl::pg::write_copy_int(&mut buf, 0u32);
         assert_eq!(buf, b"0");
     }
 
     // -- artwork tests --
+
+    use super::*;
+    use crate::model::ReleaseImage;
 
     #[test]
     fn test_artwork_primary_preferred() {
@@ -870,39 +651,39 @@ mod tests {
         assert_eq!(pick_artwork_url(&images), None);
     }
 
-    // -- dedup tests --
+    // -- dedup tests (now using wxyc_etl types) --
 
     #[test]
     fn test_dedup_release_artist() {
         let mut dedup = ArtistDedup::new();
-        assert!(dedup.insert(1001, "Autechre"));
-        assert!(dedup.insert(1001, "Boards of Canada"));
+        assert!(dedup.insert((1001, "Autechre".to_string())));
+        assert!(dedup.insert((1001, "Boards of Canada".to_string())));
         // Duplicate
-        assert!(!dedup.insert(1001, "Autechre"));
+        assert!(!dedup.insert((1001, "Autechre".to_string())));
         // Same artist, different release
-        assert!(dedup.insert(1002, "Autechre"));
+        assert!(dedup.insert((1002, "Autechre".to_string())));
     }
 
     #[test]
     fn test_dedup_track_artist() {
         let mut dedup = TrackArtistDedup::new();
-        assert!(dedup.insert(1001, 1, "Autechre"));
-        assert!(dedup.insert(1001, 2, "Autechre"));
+        assert!(dedup.insert((1001, 1, "Autechre".to_string())));
+        assert!(dedup.insert((1001, 2, "Autechre".to_string())));
         // Duplicate
-        assert!(!dedup.insert(1001, 1, "Autechre"));
+        assert!(!dedup.insert((1001, 1, "Autechre".to_string())));
         // Same release+track, different artist
-        assert!(dedup.insert(1001, 1, "Boards of Canada"));
+        assert!(dedup.insert((1001, 1, "Boards of Canada".to_string())));
     }
 
     #[test]
     fn test_dedup_label() {
         let mut dedup = LabelDedup::new();
-        assert!(dedup.insert(1001, "Warp"));
-        assert!(dedup.insert(1001, "4AD"));
+        assert!(dedup.insert((1001, "Warp".to_string())));
+        assert!(dedup.insert((1001, "4AD".to_string())));
         // Duplicate
-        assert!(!dedup.insert(1001, "Warp"));
+        assert!(!dedup.insert((1001, "Warp".to_string())));
         // Same label, different release
-        assert!(dedup.insert(1002, "Warp"));
+        assert!(dedup.insert((1002, "Warp".to_string())));
     }
 
     // -- PgOutput integration tests (require TEST_DATABASE_URL) --

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -11,112 +11,92 @@
 //! - release_style.csv
 //! - release_company.csv
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use anyhow::{Context, Result};
-use csv::Writer;
+use anyhow::Result;
+use wxyc_etl::csv_writer::{CsvFileSpec, MultiCsvWriter};
 
 use crate::model::Release;
 use crate::output::ReleaseOutput;
 
-/// Manages 9 CSV writers, one per output file.
+/// CSV file indices (matching spec order in CsvOutput::new).
+const RELEASE: usize = 0;
+const RELEASE_ARTIST: usize = 1;
+const RELEASE_LABEL: usize = 2;
+const RELEASE_TRACK: usize = 3;
+const RELEASE_TRACK_ARTIST: usize = 4;
+const RELEASE_IMAGE: usize = 5;
+const RELEASE_GENRE: usize = 6;
+const RELEASE_STYLE: usize = 7;
+const RELEASE_COMPANY: usize = 8;
+
+/// Manages 9 CSV writers via `MultiCsvWriter`, one per output file.
 pub struct CsvOutput {
-    release: Writer<fs::File>,
-    release_artist: Writer<fs::File>,
-    release_label: Writer<fs::File>,
-    release_track: Writer<fs::File>,
-    release_track_artist: Writer<fs::File>,
-    release_image: Writer<fs::File>,
-    release_genre: Writer<fs::File>,
-    release_style: Writer<fs::File>,
-    release_company: Writer<fs::File>,
-    output_dir: PathBuf,
+    csv: MultiCsvWriter,
 }
 
 impl CsvOutput {
-    /// Create a new CsvOutput, writing headers to all 6 files.
+    /// Create a new CsvOutput, writing headers to all 9 files.
     pub fn new(output_dir: &Path) -> Result<Self> {
-        fs::create_dir_all(output_dir).with_context(|| {
-            format!(
-                "Failed to create output directory: {}",
-                output_dir.display()
-            )
-        })?;
+        let specs = [
+            CsvFileSpec::new(
+                "release.csv",
+                &[
+                    "id",
+                    "status",
+                    "title",
+                    "country",
+                    "released",
+                    "notes",
+                    "data_quality",
+                    "master_id",
+                    "format",
+                ],
+            ),
+            CsvFileSpec::new(
+                "release_artist.csv",
+                &[
+                    "release_id",
+                    "artist_id",
+                    "artist_name",
+                    "extra",
+                    "anv",
+                    "position",
+                    "join_field",
+                ],
+            ),
+            CsvFileSpec::new("release_label.csv", &["release_id", "label", "catno"]),
+            CsvFileSpec::new(
+                "release_track.csv",
+                &["release_id", "sequence", "position", "title", "duration"],
+            ),
+            CsvFileSpec::new(
+                "release_track_artist.csv",
+                &["release_id", "track_sequence", "artist_name"],
+            ),
+            CsvFileSpec::new(
+                "release_image.csv",
+                &["release_id", "type", "width", "height", "uri"],
+            ),
+            CsvFileSpec::new("release_genre.csv", &["release_id", "genre"]),
+            CsvFileSpec::new("release_style.csv", &["release_id", "style"]),
+            CsvFileSpec::new(
+                "release_company.csv",
+                &[
+                    "release_id",
+                    "company_id",
+                    "company_name",
+                    "entity_type",
+                    "entity_type_name",
+                ],
+            ),
+        ];
 
-        let mut release = Self::create_writer(output_dir, "release.csv")?;
-        release.write_record([
-            "id",
-            "status",
-            "title",
-            "country",
-            "released",
-            "notes",
-            "data_quality",
-            "master_id",
-            "format",
-        ])?;
-
-        let mut release_artist = Self::create_writer(output_dir, "release_artist.csv")?;
-        release_artist.write_record([
-            "release_id",
-            "artist_id",
-            "artist_name",
-            "extra",
-            "anv",
-            "position",
-            "join_field",
-        ])?;
-
-        let mut release_label = Self::create_writer(output_dir, "release_label.csv")?;
-        release_label.write_record(["release_id", "label", "catno"])?;
-
-        let mut release_track = Self::create_writer(output_dir, "release_track.csv")?;
-        release_track.write_record(["release_id", "sequence", "position", "title", "duration"])?;
-
-        let mut release_track_artist = Self::create_writer(output_dir, "release_track_artist.csv")?;
-        release_track_artist.write_record(["release_id", "track_sequence", "artist_name"])?;
-
-        let mut release_image = Self::create_writer(output_dir, "release_image.csv")?;
-        release_image.write_record(["release_id", "type", "width", "height", "uri"])?;
-
-        let mut release_genre = Self::create_writer(output_dir, "release_genre.csv")?;
-        release_genre.write_record(["release_id", "genre"])?;
-
-        let mut release_style = Self::create_writer(output_dir, "release_style.csv")?;
-        release_style.write_record(["release_id", "style"])?;
-
-        let mut release_company = Self::create_writer(output_dir, "release_company.csv")?;
-        release_company.write_record([
-            "release_id",
-            "company_id",
-            "company_name",
-            "entity_type",
-            "entity_type_name",
-        ])?;
-
-        Ok(CsvOutput {
-            release,
-            release_artist,
-            release_label,
-            release_track,
-            release_track_artist,
-            release_image,
-            release_genre,
-            release_style,
-            release_company,
-            output_dir: output_dir.to_path_buf(),
-        })
+        let csv = MultiCsvWriter::new(output_dir, &specs)?;
+        Ok(CsvOutput { csv })
     }
 
-    fn create_writer(dir: &Path, filename: &str) -> Result<Writer<fs::File>> {
-        let path = dir.join(filename);
-        let file = fs::File::create(&path)
-            .with_context(|| format!("Failed to create {}", path.display()))?;
-        Ok(Writer::from_writer(file))
-    }
-
-    /// Write a release and all its child records to the 6 CSV files.
+    /// Write a release and all its child records to the 9 CSV files.
     pub fn write_release(&mut self, release: &Release) -> Result<()> {
         let mut ibuf = itoa::Buffer::new();
         let id_str = ibuf.format(release.id).to_string();
@@ -129,7 +109,7 @@ impl CsvOutput {
             .unwrap_or_default();
 
         // release.csv
-        self.release.write_record([
+        self.csv.writer(RELEASE).write_record([
             &id_str,
             &release.status,
             &release.title,
@@ -147,7 +127,7 @@ impl CsvOutput {
             let artist_id_str = b.format(artist.artist_id).to_string();
             let mut b2 = itoa::Buffer::new();
             let position_str = b2.format(artist.position).to_string();
-            self.release_artist.write_record([
+            self.csv.writer(RELEASE_ARTIST).write_record([
                 &id_str,
                 &artist_id_str,
                 &artist.name,
@@ -164,7 +144,7 @@ impl CsvOutput {
             let artist_id_str = b.format(artist.artist_id).to_string();
             let mut b2 = itoa::Buffer::new();
             let position_str = b2.format(artist.position).to_string();
-            self.release_artist.write_record([
+            self.csv.writer(RELEASE_ARTIST).write_record([
                 &id_str,
                 &artist_id_str,
                 &artist.name,
@@ -177,7 +157,8 @@ impl CsvOutput {
 
         // release_label.csv
         for label in &release.labels {
-            self.release_label
+            self.csv
+                .writer(RELEASE_LABEL)
                 .write_record([&id_str, &label.name, &label.catno])?;
         }
 
@@ -186,7 +167,7 @@ impl CsvOutput {
             let mut b = itoa::Buffer::new();
             let sequence = b.format(idx + 1).to_string();
 
-            self.release_track.write_record([
+            self.csv.writer(RELEASE_TRACK).write_record([
                 &id_str,
                 &sequence,
                 &track.position,
@@ -196,11 +177,13 @@ impl CsvOutput {
 
             // Track artists (both main and extra go to the same table)
             for artist in &track.artists {
-                self.release_track_artist
+                self.csv
+                    .writer(RELEASE_TRACK_ARTIST)
                     .write_record([&id_str, &sequence, &artist.name])?;
             }
             for artist in &track.extra_artists {
-                self.release_track_artist
+                self.csv
+                    .writer(RELEASE_TRACK_ARTIST)
                     .write_record([&id_str, &sequence, &artist.name])?;
             }
         }
@@ -211,7 +194,7 @@ impl CsvOutput {
             let width_str = bw.format(image.width).to_string();
             let mut bh = itoa::Buffer::new();
             let height_str = bh.format(image.height).to_string();
-            self.release_image.write_record([
+            self.csv.writer(RELEASE_IMAGE).write_record([
                 &id_str,
                 &image.image_type,
                 &width_str,
@@ -222,12 +205,16 @@ impl CsvOutput {
 
         // release_genre.csv
         for genre in &release.genres {
-            self.release_genre.write_record([&id_str, genre])?;
+            self.csv
+                .writer(RELEASE_GENRE)
+                .write_record([&id_str, genre])?;
         }
 
         // release_style.csv
         for style in &release.styles {
-            self.release_style.write_record([&id_str, style])?;
+            self.csv
+                .writer(RELEASE_STYLE)
+                .write_record([&id_str, style])?;
         }
 
         // release_company.csv
@@ -236,7 +223,7 @@ impl CsvOutput {
             let company_id_str = b.format(company.company_id).to_string();
             let mut b2 = itoa::Buffer::new();
             let entity_type_str = b2.format(company.entity_type).to_string();
-            self.release_company.write_record([
+            self.csv.writer(RELEASE_COMPANY).write_record([
                 &id_str,
                 &company_id_str,
                 &company.name,
@@ -250,21 +237,12 @@ impl CsvOutput {
 
     /// Flush all writers.
     pub fn flush(&mut self) -> Result<()> {
-        self.release.flush()?;
-        self.release_artist.flush()?;
-        self.release_label.flush()?;
-        self.release_track.flush()?;
-        self.release_track_artist.flush()?;
-        self.release_image.flush()?;
-        self.release_genre.flush()?;
-        self.release_style.flush()?;
-        self.release_company.flush()?;
-        Ok(())
+        self.csv.flush_all()
     }
 
     /// Get the output directory path.
     pub fn output_dir(&self) -> &Path {
-        &self.output_dir
+        self.csv.output_dir()
     }
 }
 
@@ -612,8 +590,8 @@ mod tests {
             "release_style.csv",
             "release_company.csv",
         ] {
-            let content1 = fs::read_to_string(dir1.path().join(filename)).unwrap();
-            let content2 = fs::read_to_string(dir2.path().join(filename)).unwrap();
+            let content1 = std::fs::read_to_string(dir1.path().join(filename)).unwrap();
+            let content2 = std::fs::read_to_string(dir2.path().join(filename)).unwrap();
             assert_eq!(
                 content1, content2,
                 "Non-deterministic output for {}",

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -177,14 +177,18 @@ impl CsvOutput {
 
             // Track artists (both main and extra go to the same table)
             for artist in &track.artists {
-                self.csv
-                    .writer(RELEASE_TRACK_ARTIST)
-                    .write_record([&id_str, &sequence, &artist.name])?;
+                self.csv.writer(RELEASE_TRACK_ARTIST).write_record([
+                    &id_str,
+                    &sequence,
+                    &artist.name,
+                ])?;
             }
             for artist in &track.extra_artists {
-                self.csv
-                    .writer(RELEASE_TRACK_ARTIST)
-                    .write_record([&id_str, &sequence, &artist.name])?;
+                self.csv.writer(RELEASE_TRACK_ARTIST).write_record([
+                    &id_str,
+                    &sequence,
+                    &artist.name,
+                ])?;
             }
         }
 

--- a/tests/oracle_tests.rs
+++ b/tests/oracle_tests.rs
@@ -2,6 +2,10 @@
 //!
 //! These tests parse releases_fixture.xml and diff each CSV against
 //! the expected output copied from discogs-cache/tests/fixtures/csv/.
+//!
+//! Text normalization is provided by `wxyc_etl::text::normalize_artist_name()`,
+//! the shared implementation used by all WXYC ETL repos. The parity tests in
+//! `src/filter.rs` verify normalization equivalence.
 
 use std::collections::HashSet;
 use std::fs;


### PR DESCRIPTION
## Summary

- Replace local `normalize_artist()` implementation in `filter.rs` with delegation to `wxyc_etl::text::normalize_artist_name()`, removing the hand-rolled Unicode category detection code
- Replace 9 individual `csv::Writer<File>` fields in `writer.rs` with `wxyc_etl::csv_writer::MultiCsvWriter`
- Replace local COPY TEXT helpers, dedup structs, `extract_year`, `pick_artwork_url`, and manual buffer management in `pg_output.rs` with `wxyc_etl::pg` module imports (`BatchCopier`, `ArtistDedup`, etc.)
- Implement `wxyc_etl::pg::ImageRef` for `model::ReleaseImage` to support generic artwork selection
- Remove `unicode-normalization` from direct dependencies (now transitive through `wxyc-etl`)
- Add normalization parity tests verifying equivalence between local and shared implementations
- Update CLAUDE.md and oracle test documentation to reference `wxyc-etl` as the normalization source of truth

Closes WXYC/discogs-xml-converter#21

## Test plan

- [x] All 120 tests pass (95 unit, 8 main, 10 CLI integration, 7 oracle)
- [x] Oracle tests confirm byte-identical CSV output before/after migration
- [x] Normalization parity tests verify `normalize_artist()` == `normalize_artist_name()` for diacritics, combining characters, whitespace, case, empty strings, and WXYC example artists
- [x] `cargo clippy` reports no warnings
- [x] `cargo fmt` confirms clean formatting
- [ ] PostgreSQL integration tests pass with `TEST_DATABASE_URL` (CI-gated)