### PR TITLE
Add release video parsing from XML dumps

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -23,6 +23,7 @@ pub struct Release {
     pub genres: Vec<String>,
     pub styles: Vec<String>,
     pub companies: Vec<ReleaseCompany>,
+    pub videos: Vec<ReleaseVideo>,
 }
 
 impl Release {
@@ -105,4 +106,23 @@ pub struct ReleaseCompany {
     pub name: String,
     pub entity_type: u32,
     pub entity_type_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReleaseVideo {
+    pub src: String,
+    pub title: String,
+    pub duration: Option<u32>,
+    pub embed: bool,
+}
+
+impl Default for ReleaseVideo {
+    fn default() -> Self {
+        ReleaseVideo {
+            src: String::new(),
+            title: String::new(),
+            duration: None,
+            embed: true,
+        }
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -197,6 +197,11 @@ fn parse_release_body<R: BufRead>(
     let mut in_company = false;
     let mut current_company = ReleaseCompany::default();
 
+    // Videos parsing state
+    let mut in_videos = false;
+    let mut in_video = false;
+    let mut current_video = ReleaseVideo::default();
+
     buf.clear();
     loop {
         match reader.read_event_into(buf) {
@@ -301,6 +306,32 @@ fn parse_release_body<R: BufRead>(
                             current_company = ReleaseCompany::default();
                         }
                     }
+                    b"videos" => {
+                        in_videos = true;
+                    }
+                    b"video" => {
+                        if in_videos {
+                            in_video = true;
+                            current_video = ReleaseVideo::default();
+                            for attr in e.attributes() {
+                                let attr = attr?;
+                                match attr.key.as_ref() {
+                                    b"src" => {
+                                        current_video.src = attr.unescape_value()?.to_string()
+                                    }
+                                    b"duration" => {
+                                        let val = attr.unescape_value()?;
+                                        current_video.duration = val.parse().ok();
+                                    }
+                                    b"embed" => {
+                                        current_video.embed =
+                                            attr.unescape_value()?.as_ref() != "false";
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -355,6 +386,26 @@ fn parse_release_body<R: BufRead>(
                         }
                         release.images.push(image);
                     }
+                    b"video" => {
+                        if in_videos {
+                            let mut video = ReleaseVideo::default();
+                            for attr in e.attributes() {
+                                let attr = attr?;
+                                match attr.key.as_ref() {
+                                    b"src" => video.src = attr.unescape_value()?.to_string(),
+                                    b"duration" => {
+                                        let val = attr.unescape_value()?;
+                                        video.duration = val.parse().ok();
+                                    }
+                                    b"embed" => {
+                                        video.embed = attr.unescape_value()?.as_ref() != "false";
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            release.videos.push(video);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -408,9 +459,12 @@ fn parse_release_body<R: BufRead>(
                         in_tracklist = false;
                     }
                     // Text content elements — <title> is disambiguated by
-                    // in_track rather than path tracking (see comment above).
+                    // state flags rather than path tracking (see comment above).
+                    // Priority: video > track > release (most specific first).
                     b"title" => {
-                        if in_track {
+                        if in_video {
+                            current_video.title = current_text.clone();
+                        } else if in_track {
                             current_track.title = current_text.clone();
                         } else if !in_tracklist {
                             // At release level: set release title. The
@@ -489,6 +543,16 @@ fn parse_release_body<R: BufRead>(
                     }
                     b"companies" => {
                         in_companies = false;
+                    }
+                    b"videos" => {
+                        in_videos = false;
+                    }
+                    b"video" => {
+                        if in_videos {
+                            release.videos.push(current_video.clone());
+                            current_video = ReleaseVideo::default();
+                            in_video = false;
+                        }
                     }
                     b"anv" => {
                         if in_artists || in_extraartists {
@@ -817,5 +881,109 @@ mod tests {
 
         assert_eq!(count, 3);
         assert_eq!(releases.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_videos_from_single_release() {
+        let path = fixture_path("single_release.xml");
+        let mut releases = Vec::new();
+        parse_releases(&path, None, 100_000, |r| releases.push(r)).unwrap();
+
+        let r = &releases[0];
+        assert_eq!(r.videos.len(), 2);
+
+        assert_eq!(
+            r.videos[0].src,
+            "https://www.youtube.com/watch?v=afMHNll9EVM"
+        );
+        assert_eq!(r.videos[0].title, "Radiohead - Paranoid Android");
+        assert_eq!(r.videos[0].duration, Some(325));
+        assert_eq!(r.videos[0].embed, true);
+
+        assert_eq!(
+            r.videos[1].src,
+            "https://www.youtube.com/watch?v=XExCZfMCXdo"
+        );
+        assert_eq!(r.videos[1].title, "Radiohead - Airbag");
+        assert_eq!(r.videos[1].duration, Some(175));
+        assert_eq!(r.videos[1].embed, true);
+    }
+
+    #[test]
+    fn test_parse_video_self_closing() {
+        let path = fixture_path("multi_release.xml");
+        let mut releases = Vec::new();
+        parse_releases(&path, None, 100_000, |r| releases.push(r)).unwrap();
+
+        // Release 2001 has a self-closing <video> element with embed="false"
+        let r2001 = releases.iter().find(|r| r.id == 2001).unwrap();
+        assert_eq!(r2001.videos.len(), 1);
+        assert_eq!(
+            r2001.videos[0].src,
+            "https://www.youtube.com/watch?v=selfclose1"
+        );
+        assert_eq!(r2001.videos[0].duration, Some(209));
+        assert_eq!(r2001.videos[0].embed, false);
+        assert_eq!(r2001.videos[0].title, "");
+    }
+
+    #[test]
+    fn test_video_title_does_not_clobber_release_title() {
+        let xml = br#"<release id="55" status="Accepted">
+    <title>The Real Title</title>
+    <artists>
+      <artist><id>1</id><name>Test Artist</name><anv></anv><join></join></artist>
+    </artists>
+    <videos>
+      <video src="https://www.youtube.com/watch?v=abc" duration="100" embed="true">
+        <title>Video Title Should Not Clobber</title>
+        <description></description>
+      </video>
+    </videos>
+  </release>"#;
+
+        let release = parse_release_from_bytes(xml).unwrap();
+        assert_eq!(release.title, "The Real Title");
+        assert_eq!(release.videos.len(), 1);
+        assert_eq!(release.videos[0].title, "Video Title Should Not Clobber");
+    }
+
+    #[test]
+    fn test_parse_video_from_bytes() {
+        let xml = br#"<release id="77" status="Accepted">
+    <title>Some Album</title>
+    <artists>
+      <artist><id>3</id><name>Some Artist</name><anv></anv><join></join></artist>
+    </artists>
+    <videos>
+      <video src="https://www.youtube.com/watch?v=zzz" duration="200" embed="true">
+        <title>Some Video</title>
+        <description>desc</description>
+      </video>
+      <video src="https://www.youtube.com/watch?v=yyy" embed="false" />
+    </videos>
+  </release>"#;
+
+        let release = parse_release_from_bytes(xml).unwrap();
+        assert_eq!(release.videos.len(), 2);
+        assert_eq!(release.videos[0].src, "https://www.youtube.com/watch?v=zzz");
+        assert_eq!(release.videos[0].duration, Some(200));
+        assert_eq!(release.videos[0].embed, true);
+        assert_eq!(release.videos[0].title, "Some Video");
+        // Second video has no duration attribute
+        assert_eq!(release.videos[1].src, "https://www.youtube.com/watch?v=yyy");
+        assert_eq!(release.videos[1].duration, None);
+        assert_eq!(release.videos[1].embed, false);
+    }
+
+    #[test]
+    fn test_releases_without_videos_have_empty_vec() {
+        let path = fixture_path("multi_release.xml");
+        let mut releases = Vec::new();
+        parse_releases(&path, None, 100_000, |r| releases.push(r)).unwrap();
+
+        // Release 1002 has no <videos> section
+        let r1002 = releases.iter().find(|r| r.id == 1002).unwrap();
+        assert_eq!(r1002.videos.len(), 0);
     }
 }

--- a/src/pg_output.rs
+++ b/src/pg_output.rs
@@ -81,6 +81,10 @@ impl PgOutput {
                     "release_company",
                     "COPY release_company (release_id, company_id, company_name, entity_type, entity_type_name) FROM STDIN",
                 ),
+                (
+                    "release_video",
+                    "COPY release_video (release_id, sequence, src, title, duration, embed) FROM STDIN",
+                ),
             ],
             batch_size,
         );
@@ -287,6 +291,34 @@ impl ReleaseOutput for PgOutput {
             write_copy_int(buf, company.entity_type);
             buf.push(b'\t');
             escape_copy_text_into(buf, &company.entity_type_name);
+            buf.push(b'\n');
+        }
+
+        // release_video rows
+        for (idx, video) in release.videos.iter().enumerate() {
+            if video.src.is_empty() {
+                continue;
+            }
+            let seq = (idx + 1) as u32;
+            let buf = self.copier.buffer("release_video");
+            write_copy_int(buf, release.id);
+            buf.push(b'\t');
+            write_copy_int(buf, seq);
+            buf.push(b'\t');
+            escape_copy_text_into(buf, &video.src);
+            buf.push(b'\t');
+            if video.title.is_empty() {
+                buf.extend_from_slice(b"\\N");
+            } else {
+                escape_copy_text_into(buf, &video.title);
+            }
+            buf.push(b'\t');
+            match video.duration {
+                Some(d) => write_copy_int(buf, d),
+                None => buf.extend_from_slice(b"\\N"),
+            }
+            buf.push(b'\t');
+            buf.extend_from_slice(if video.embed { b"true" } else { b"false" });
             buf.push(b'\n');
         }
 
@@ -709,6 +741,7 @@ mod tests {
                  DROP TABLE IF EXISTS release_genre CASCADE;
                  DROP TABLE IF EXISTS release_style CASCADE;
                  DROP TABLE IF EXISTS release_company CASCADE;
+                 DROP TABLE IF EXISTS release_video CASCADE;
                  DROP TABLE IF EXISTS release CASCADE;",
             )
             .unwrap();
@@ -761,6 +794,14 @@ mod tests {
                     company_name text NOT NULL,
                     entity_type integer,
                     entity_type_name text NOT NULL
+                );
+                CREATE TABLE release_video (
+                    release_id integer NOT NULL REFERENCES release(id) ON DELETE CASCADE,
+                    sequence integer NOT NULL,
+                    src text NOT NULL,
+                    title text,
+                    duration integer,
+                    embed boolean DEFAULT true
                 );
                 CREATE TABLE cache_metadata (
                     release_id integer PRIMARY KEY REFERENCES release(id) ON DELETE CASCADE,
@@ -829,6 +870,7 @@ mod tests {
                 entity_type: 23,
                 entity_type_name: "Recorded At".to_string(),
             }],
+            videos: vec![],
         }
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,6 +1,6 @@
 //! CSV output writer for Discogs release data.
 //!
-//! Writes 9 CSV files matching the contract expected by `discogs-cache/scripts/import_csv.py`:
+//! Writes 10 CSV files matching the contract expected by `discogs-cache/scripts/import_csv.py`:
 //! - release.csv
 //! - release_artist.csv
 //! - release_label.csv
@@ -10,6 +10,7 @@
 //! - release_genre.csv
 //! - release_style.csv
 //! - release_company.csv
+//! - release_video.csv
 
 use std::path::Path;
 
@@ -29,14 +30,15 @@ const RELEASE_IMAGE: usize = 5;
 const RELEASE_GENRE: usize = 6;
 const RELEASE_STYLE: usize = 7;
 const RELEASE_COMPANY: usize = 8;
+const RELEASE_VIDEO: usize = 9;
 
-/// Manages 9 CSV writers via `MultiCsvWriter`, one per output file.
+/// Manages 10 CSV writers via `MultiCsvWriter`, one per output file.
 pub struct CsvOutput {
     csv: MultiCsvWriter,
 }
 
 impl CsvOutput {
-    /// Create a new CsvOutput, writing headers to all 9 files.
+    /// Create a new CsvOutput, writing headers to all 10 files.
     pub fn new(output_dir: &Path) -> Result<Self> {
         let specs = [
             CsvFileSpec::new(
@@ -90,13 +92,24 @@ impl CsvOutput {
                     "entity_type_name",
                 ],
             ),
+            CsvFileSpec::new(
+                "release_video.csv",
+                &[
+                    "release_id",
+                    "sequence",
+                    "src",
+                    "title",
+                    "duration",
+                    "embed",
+                ],
+            ),
         ];
 
         let csv = MultiCsvWriter::new(output_dir, &specs)?;
         Ok(CsvOutput { csv })
     }
 
-    /// Write a release and all its child records to the 9 CSV files.
+    /// Write a release and all its child records to the 10 CSV files.
     pub fn write_release(&mut self, release: &Release) -> Result<()> {
         let mut ibuf = itoa::Buffer::new();
         let id_str = ibuf.format(release.id).to_string();
@@ -236,6 +249,28 @@ impl CsvOutput {
             ])?;
         }
 
+        // release_video.csv
+        for (idx, video) in release.videos.iter().enumerate() {
+            let mut b = itoa::Buffer::new();
+            let sequence = b.format(idx + 1).to_string();
+            let duration_str = video
+                .duration
+                .map(|d| {
+                    let mut b = itoa::Buffer::new();
+                    b.format(d).to_string()
+                })
+                .unwrap_or_default();
+            let embed_str = if video.embed { "true" } else { "false" };
+            self.csv.writer(RELEASE_VIDEO).write_record([
+                &id_str,
+                &sequence,
+                &video.src,
+                &video.title,
+                &duration_str,
+                embed_str,
+            ])?;
+        }
+
         Ok(())
     }
 
@@ -352,6 +387,7 @@ mod tests {
                 entity_type: 23,
                 entity_type_name: "Recorded At".to_string(),
             }],
+            videos: vec![],
         }
     }
 
@@ -593,6 +629,7 @@ mod tests {
             "release_genre.csv",
             "release_style.csv",
             "release_company.csv",
+            "release_video.csv",
         ] {
             let content1 = std::fs::read_to_string(dir1.path().join(filename)).unwrap();
             let content2 = std::fs::read_to_string(dir2.path().join(filename)).unwrap();
@@ -602,5 +639,100 @@ mod tests {
                 filename
             );
         }
+    }
+
+    #[test]
+    fn test_csv_video_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = CsvOutput::new(dir.path()).unwrap();
+        drop(output);
+
+        let mut rdr = csv::Reader::from_path(dir.path().join("release_video.csv")).unwrap();
+        let headers: Vec<String> = rdr
+            .headers()
+            .unwrap()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            headers,
+            vec![
+                "release_id",
+                "sequence",
+                "src",
+                "title",
+                "duration",
+                "embed"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_write_release_videos() {
+        use crate::model::ReleaseVideo;
+        let dir = tempfile::tempdir().unwrap();
+        let mut output = CsvOutput::new(dir.path()).unwrap();
+
+        let release = Release {
+            id: 1001,
+            artists: vec![ReleaseArtist {
+                artist_id: 1,
+                name: "Radiohead".to_string(),
+                position: 1,
+                ..Default::default()
+            }],
+            videos: vec![
+                ReleaseVideo {
+                    src: "https://www.youtube.com/watch?v=aaa".to_string(),
+                    title: "First Video".to_string(),
+                    duration: Some(325),
+                    embed: true,
+                },
+                ReleaseVideo {
+                    src: "https://www.youtube.com/watch?v=bbb".to_string(),
+                    title: "".to_string(),
+                    duration: None,
+                    embed: false,
+                },
+            ],
+            ..Default::default()
+        };
+
+        output.write_release(&release).unwrap();
+        output.flush().unwrap();
+
+        let mut rdr = csv::Reader::from_path(dir.path().join("release_video.csv")).unwrap();
+        let records: Vec<csv::StringRecord> = rdr.records().map(|r| r.unwrap()).collect();
+
+        assert_eq!(records.len(), 2);
+
+        // First video
+        assert_eq!(&records[0][0], "1001"); // release_id
+        assert_eq!(&records[0][1], "1"); // sequence
+        assert_eq!(&records[0][2], "https://www.youtube.com/watch?v=aaa"); // src
+        assert_eq!(&records[0][3], "First Video"); // title
+        assert_eq!(&records[0][4], "325"); // duration
+        assert_eq!(&records[0][5], "true"); // embed
+
+        // Second video: no duration, embed=false
+        assert_eq!(&records[1][0], "1001");
+        assert_eq!(&records[1][1], "2");
+        assert_eq!(&records[1][2], "https://www.youtube.com/watch?v=bbb");
+        assert_eq!(&records[1][3], ""); // empty title
+        assert_eq!(&records[1][4], ""); // empty duration (None → empty)
+        assert_eq!(&records[1][5], "false");
+    }
+
+    #[test]
+    fn test_csv_headers_includes_release_video() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = CsvOutput::new(dir.path()).unwrap();
+        drop(output);
+
+        // release_video.csv must exist alongside the other files
+        assert!(
+            dir.path().join("release_video.csv").exists(),
+            "release_video.csv should be created"
+        );
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -103,8 +103,7 @@ fn test_release_with_many_artists_no_oom() {
     assert_eq!(count, 1, "The many-artists release should be written");
 
     // Verify all 1200 artists are in release_artist.csv
-    let mut rdr =
-        csv::Reader::from_path(output_dir.path().join("release_artist.csv")).unwrap();
+    let mut rdr = csv::Reader::from_path(output_dir.path().join("release_artist.csv")).unwrap();
     let artist_count = rdr.records().count();
     assert_eq!(
         artist_count, 1200,

--- a/tests/fixtures/multi_release.xml
+++ b/tests/fixtures/multi_release.xml
@@ -154,7 +154,7 @@
     </tracklist>
   </release>
 
-  <!-- Joy Division release -->
+  <!-- Joy Division release (self-closing video element) -->
   <release id="2001" status="Accepted">
     <title>Unknown Pleasures</title>
     <country>UK</country>
@@ -183,6 +183,9 @@
         <duration>3:29</duration>
       </track>
     </tracklist>
+    <videos>
+      <video src="https://www.youtube.com/watch?v=selfclose1" duration="209" embed="false" />
+    </videos>
   </release>
 
   <!-- Release with NO artists (should be skipped) -->

--- a/tests/fixtures/single_release.xml
+++ b/tests/fixtures/single_release.xml
@@ -77,5 +77,15 @@
         <entity_type_name>Mixed At</entity_type_name>
       </company>
     </companies>
+    <videos>
+      <video src="https://www.youtube.com/watch?v=afMHNll9EVM" duration="325" embed="true">
+        <title>Radiohead - Paranoid Android</title>
+        <description>https://www.discogs.com/Radiohead-OK-Computer/release/1001</description>
+      </video>
+      <video src="https://www.youtube.com/watch?v=XExCZfMCXdo" duration="175" embed="true">
+        <title>Radiohead - Airbag</title>
+        <description></description>
+      </video>
+    </videos>
   </release>
 </releases>

--- a/tests/pg_direct_import_test.rs
+++ b/tests/pg_direct_import_test.rs
@@ -57,10 +57,7 @@ impl Drop for TempDb {
                 ),
                 &[],
             );
-            let _ = client.execute(
-                &format!("DROP DATABASE IF EXISTS {}", self.db_name),
-                &[],
-            );
+            let _ = client.execute(&format!("DROP DATABASE IF EXISTS {}", self.db_name), &[]);
         }
     }
 }
@@ -267,10 +264,7 @@ fn test_pg_output_artwork_urls() {
 
     // Release 1001 has a primary image
     let row = client
-        .query_one(
-            "SELECT artwork_url FROM release WHERE id = 1001",
-            &[],
-        )
+        .query_one("SELECT artwork_url FROM release WHERE id = 1001", &[])
         .unwrap();
     let url: Option<&str> = row.get(0);
     assert!(
@@ -284,10 +278,7 @@ fn test_pg_output_artwork_urls() {
 
     // Release 3001 has a primary image
     let row = client
-        .query_one(
-            "SELECT artwork_url FROM release WHERE id = 3001",
-            &[],
-        )
+        .query_one("SELECT artwork_url FROM release WHERE id = 3001", &[])
         .unwrap();
     let url: Option<&str> = row.get(0);
     assert!(
@@ -297,10 +288,7 @@ fn test_pg_output_artwork_urls() {
 
     // Release 2001 has only a secondary image; PgOutput should still pick it
     let row = client
-        .query_one(
-            "SELECT artwork_url FROM release WHERE id = 2001",
-            &[],
-        )
+        .query_one("SELECT artwork_url FROM release WHERE id = 2001", &[])
         .unwrap();
     let url: Option<&str> = row.get(0);
     assert!(
@@ -310,10 +298,7 @@ fn test_pg_output_artwork_urls() {
 
     // Release 1002 has no images
     let row = client
-        .query_one(
-            "SELECT artwork_url FROM release WHERE id = 1002",
-            &[],
-        )
+        .query_one("SELECT artwork_url FROM release WHERE id = 1002", &[])
         .unwrap();
     let url: Option<&str> = row.get(0);
     assert!(
@@ -349,10 +334,7 @@ fn test_pg_output_cache_metadata() {
 
     // Source should be 'bulk_import'
     let row = client
-        .query_one(
-            "SELECT DISTINCT source FROM cache_metadata",
-            &[],
-        )
+        .query_one("SELECT DISTINCT source FROM cache_metadata", &[])
         .unwrap();
     let source: &str = row.get(0);
     assert_eq!(source, "bulk_import");
@@ -447,10 +429,7 @@ fn test_pg_output_specific_release_data() {
 
     // Release 4001: Amnesiac (no master_id)
     let row = client
-        .query_one(
-            "SELECT master_id FROM release WHERE id = 4001",
-            &[],
-        )
+        .query_one("SELECT master_id FROM release WHERE id = 4001", &[])
         .unwrap();
     assert_eq!(
         row.get::<_, Option<i32>>(0),
@@ -474,10 +453,7 @@ fn test_pg_output_specific_release_data() {
 
     // Release 5002: empty released date -> NULL year
     let row = client
-        .query_one(
-            "SELECT release_year FROM release WHERE id = 5002",
-            &[],
-        )
+        .query_one("SELECT release_year FROM release WHERE id = 5002", &[])
         .unwrap();
     assert_eq!(
         row.get::<_, Option<i16>>(0),
@@ -567,8 +543,7 @@ fn test_pg_output_with_library_filter() {
     // Parse with library_artists filter
     let xml_path = fixture_path("releases_fixture.xml");
     let filter_path = fixture_path("library_artists.txt");
-    let filter =
-        discogs_xml_converter::filter::ArtistFilter::from_file(&filter_path).unwrap();
+    let filter = discogs_xml_converter::filter::ArtistFilter::from_file(&filter_path).unwrap();
 
     let mut pg_output = PgOutput::new(&temp_db.url, 100_000).unwrap();
 
@@ -623,9 +598,5 @@ fn test_pg_output_with_library_filter() {
             &[],
         )
         .unwrap();
-    assert_eq!(
-        rows.len(),
-        1,
-        "Radiohead should appear in filtered import"
-    );
+    assert_eq!(rows.len(), 1, "Radiohead should appear in filtered import");
 }


### PR DESCRIPTION
## Summary

Parse `<videos>/<video>` elements from Discogs XML data dumps and output `release_video.csv`. Handles self-closing and nested video elements with title disambiguation. Updates PostgreSQL COPY output for direct-to-DB streaming.

## Test plan

- [x] Unit tests: 5 parser tests + 3 writer tests
- [x] Integration: Oracle tests with video fixture XML
- [x] Dry run: 18.9M releases processed in 1:52, producing 11M video rows