### PR TITLE
Migrate to standardized cache-builder CLI shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Purpose-built Rust tool for converting Discogs XML data dumps to CSV files compa
 - `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` using `wxyc_etl::csv_writer::MultiCsvWriter` for 9 CSV files matching `import_csv.py` contract
 - `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; uses `wxyc_etl::pg::BatchCopier` for FK-ordered flush and `wxyc_etl::pg::copy` for COPY TEXT escaping; domain-specific post-import logic (artwork URLs, track counts, cache_metadata) remains local
 - `filter.rs` -- `ArtistFilter` HashSet-based artist name filtering with alias support; normalization delegates to `wxyc_etl::text::normalize_artist_name()`
-- `main.rs` -- CLI using clap derive; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer); output dispatch between CSV and PG modes
+- `main.rs` -- CLI using clap derive with `build` / `import` subcommands; flattens `wxyc_etl::cli::{DatabaseArgs, ResumableBuildArgs, ImportArgs}` for the cache-builder convention; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer); output dispatch between CSV and PG sinks
 
 ### Parallel Processing Pipeline
 
@@ -24,7 +24,7 @@ Release processing uses a three-stage pipeline for multi-core parallelism:
 2. **Rayon worker pool** -- receives batches, parses XML from bytes + normalizes/filters artists in parallel using `par_iter()` (order-preserving)
 3. **Writer (main thread)** -- writes matched releases via `ReleaseOutput` trait, preserving XML document order
 
-The writer stage dispatches to either `CsvOutput` (CSV files) or `PgOutput` (PostgreSQL COPY) based on the `--database-url` flag. In directory mode, the scanner starts before artist/label processing completes (`start_scanner` + `consume_releases`), overlapping the large file read with smaller-file work. Artist and label XML files are processed in parallel via `std::thread::scope` when both are present.
+The writer stage dispatches to either `CsvOutput` (CSV files) or `PgOutput` (PostgreSQL COPY) based on the chosen subcommand: `build` writes CSVs to `--data-dir`, `import` streams to PostgreSQL via `--database-url` (or the `DATABASE_URL_DISCOGS` env fallback resolved through `wxyc_etl::cli::resolve_database_url`). In directory mode, the scanner starts before artist/label processing completes (`start_scanner` + `consume_releases`), overlapping the large file read with smaller-file work. Artist and label XML files are processed in parallel via `std::thread::scope` when both are present.
 
 ### Output Architecture
 
@@ -70,6 +70,7 @@ cargo build --release   # produces target/release/discogs-xml-converter
 - `cargo clippy` for linting
 - Targets macOS ARM64 and Linux x86_64
 
+<<<<<<< HEAD
 ## Observability
 
 `main.rs` initializes `wxyc_etl::logger` at startup. Logs emit as one JSON object per line on stdout; panics and `tracing::error!` events forward to Sentry when `SENTRY_DSN` is set in the environment. Without a DSN, JSON logging still works and Sentry stays inactive.
@@ -81,6 +82,16 @@ Sentry tags applied to every event:
 - `step` -- set per-span via `tracing::info_span!("...", step = "...")`
 
 TODO: provision `SENTRY_DSN` in the environments that invoke this tool (discogs-etl GitHub Actions workflow + any manual cache rebuild scripts on EC2). DSN provisioning is tracked separately from this wireup.
+=======
+## CLI shape (cache-builder convention)
+
+The tool exposes two subcommands that compose shared `wxyc_etl::cli` argument groups:
+
+- `discogs-xml-converter build <input> [--data-dir DIR] [--state-file FILE] [--resume] [--library-artists FILE] [--limit N]` — convert XML to CSV files in `--data-dir` (defaults to `./data`). `--resume` is accepted for parity with other cache builders but is currently a no-op (this tool is single-pass).
+- `discogs-xml-converter import <input> --database-url URL [--data-dir DIR] [--fresh] [--batch-size N]` — stream releases directly into PostgreSQL via COPY. `--database-url` falls back to the `DATABASE_URL_DISCOGS` environment variable. `--fresh` runs `TRUNCATE release ... CASCADE` before importing.
+
+`--output-dir` is accepted as a deprecation alias for `--data-dir` (with a stderr warning) for one release. The deprecation alias is enforced in tests; remove it in the next breaking-change cycle once all callers (`discogs-etl`'s `run_pipeline.py`) have migrated.
+>>>>>>> 695744b (Migrate to standardized cache-builder CLI)
 
 ## Key Design Decisions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -105,9 +105,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -164,17 +164,17 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -217,9 +217,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -238,10 +238,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.5.60"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -249,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -261,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -273,21 +284,33 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -337,12 +360,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -364,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -399,13 +430,14 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -459,9 +491,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -469,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -516,9 +548,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -610,16 +642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +677,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -685,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -712,9 +735,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -774,6 +797,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -935,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -945,12 +977,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -979,15 +1011,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -998,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1009,10 +1041,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1031,15 +1065,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -1099,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest",
@@ -1134,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1364,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1458,18 +1492,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "postgres"
-version = "0.19.12"
+version = "0.19.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
+checksum = "aacf632d0554ff75f58183694f41dc8999c8a3a43a386994d0ec2d034f1dfbe1"
 dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
@@ -1481,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
  "base64",
  "byteorder",
@@ -1492,16 +1526,16 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.2",
+ "rand 0.10.1",
  "sha2",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
@@ -1629,7 +1663,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.39",
@@ -1689,12 +1723,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1736,10 +1781,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1976,9 +2027,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentry"
@@ -2134,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2160,9 +2211,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -2254,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -2363,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2378,9 +2429,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2392,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2409,7 +2460,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.1",
  "socket2",
  "tokio",
  "tokio-util",
@@ -2566,9 +2617,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uname"
@@ -2729,11 +2780,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2742,7 +2793,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2756,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2769,23 +2820,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2793,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2806,9 +2853,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2849,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2887,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -3070,6 +3117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,7 +3210,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wxyc-etl"
 version = "0.1.0"
-source = "git+https://github.com/WXYC/wxyc-etl.git?branch=main#23875af235374845568298bab860cdc1af32b9bf"
+source = "git+https://github.com/WXYC/wxyc-etl.git?branch=main#c958a51563cb69c645a5cda7d127e1a964d1c702"
 dependencies = [
  "anyhow",
  "clap",
@@ -3216,18 +3269,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -12,48 +12,85 @@ Replaces three Python scripts with a single binary:
 
 ## Usage
 
-```bash
-# Convert all releases to CSV (drop-in replacement for discogs-xml2db)
-discogs-xml-converter releases.xml.gz --output-dir /path/to/csv/
+The CLI follows the WXYC cache-builder convention with two subcommands:
 
-# Convert and filter to library artists only (replaces xml2db + fix + filter)
-discogs-xml-converter releases.xml.gz --output-dir /path/to/filtered/ \
+```text
+discogs-xml-converter build  <input> [--data-dir DIR] [--library-artists FILE] [--limit N] [--resume]
+discogs-xml-converter import <input> [--database-url URL] [--data-dir DIR] [--fresh] [--batch-size N]
+```
+
+`build` writes CSV files; `import` streams releases directly into PostgreSQL via COPY.
+
+### `build` — XML to CSV
+
+```bash
+# Convert all releases to CSV
+discogs-xml-converter build releases.xml.gz --data-dir /path/to/csv/
+
+# Convert and filter to library artists only
+discogs-xml-converter build releases.xml.gz --data-dir /path/to/filtered/ \
   --library-artists library_artists.txt
 
 # Limit records for testing
-discogs-xml-converter releases.xml.gz --output-dir /tmp/test/ --limit 100
+discogs-xml-converter build releases.xml.gz --data-dir /tmp/test/ --limit 100
 ```
 
-### Direct-to-PostgreSQL mode
+### `import` — XML to PostgreSQL
 
-Stream releases directly into PostgreSQL, bypassing the CSV round-trip:
+`--database-url` is required; if omitted the CLI falls back to the `DATABASE_URL_DISCOGS` environment variable.
 
 ```bash
 # Stream releases directly into PostgreSQL
-discogs-xml-converter /path/to/xml-dumps/ \
-  --output-dir /path/to/supplementary/ \
+discogs-xml-converter import /path/to/xml-dumps/ \
+  --data-dir /path/to/supplementary/ \
   --library-artists library_artists.txt \
   --database-url postgresql://localhost:5432/discogs
 
-# With custom batch size (default: 10000)
-discogs-xml-converter releases.xml.gz \
-  --output-dir /tmp/out/ \
+# Same, using DATABASE_URL_DISCOGS env var
+DATABASE_URL_DISCOGS=postgresql://localhost:5432/discogs \
+  discogs-xml-converter import /path/to/xml-dumps/ \
+    --library-artists library_artists.txt
+
+# Drop existing release rows before importing (--fresh truncates release CASCADE)
+discogs-xml-converter import releases.xml.gz \
   --database-url postgresql://localhost:5432/discogs \
-  --batch-size 5000
+  --fresh
+
+# Tune batch size (default: 100000)
+discogs-xml-converter import releases.xml.gz \
+  --database-url postgresql://localhost:5432/discogs \
+  --batch-size 50000
 ```
 
-When `--database-url` is provided, releases are streamed into PostgreSQL via COPY instead of being written to CSV files. Supplementary CSVs (artist_alias.csv, label_hierarchy.csv) are still written to `--output-dir`.
+Supplementary CSVs (artist_alias.csv, label_hierarchy.csv) are still written to `--data-dir` in directory-input mode.
 
 ### Options
 
+Common to both subcommands:
+
 | Flag | Description |
 |---|---|
-| `--output-dir DIR` | Output directory for CSV files (required) |
+| `--data-dir DIR` | Working directory for CSV outputs (default: `./data`) |
 | `--library-artists FILE` | Filter to releases by artists in this file (one per line) |
 | `--limit N` | Stop after N releases |
 | `--progress-interval N` | Log progress every N releases (default: 100000) |
-| `--database-url URL` | Stream releases directly into PostgreSQL via COPY |
-| `--batch-size N` | Releases to buffer before flushing to PostgreSQL (default: 10000) |
+
+`build` only:
+
+| Flag | Description |
+|---|---|
+| `--resume` | Reserved for future resumable builds (currently a no-op; this tool is single-pass) |
+| `--state-file FILE` | Path to the state file used by `--resume` (default: `./state.json`) |
+
+`import` only:
+
+| Flag | Description |
+|---|---|
+| `--database-url URL` | PostgreSQL connection URL. Falls back to `DATABASE_URL_DISCOGS` |
+| `--fresh` | `TRUNCATE release ... CASCADE` before importing |
+| `--batch-size N` | Releases to buffer before flushing to PostgreSQL (default: 100000) |
+
+`--output-dir` is accepted as a deprecated alias for `--data-dir` and emits a stderr warning. It will be removed in the next release.
 
 Gzipped input is auto-detected by `.gz` extension.
 
@@ -125,8 +162,8 @@ Feed the output into the `--csv-dir` pipeline mode:
 
 ```bash
 # Convert and filter
-discogs-xml-converter releases.xml.gz \
-  --output-dir /path/to/filtered/ \
+discogs-xml-converter build releases.xml.gz \
+  --data-dir /path/to/filtered/ \
   --library-artists library_artists.txt
 
 # Run database build

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,10 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use crossbeam_channel::Sender;
 use log::{info, warn};
+use wxyc_etl::cli::{resolve_database_url, DatabaseArgs, ImportArgs, ResumableBuildArgs};
 
 use discogs_xml_converter::artist_parser::parse_artists;
 use discogs_xml_converter::artist_writer::ArtistCsvOutput;
@@ -20,48 +21,97 @@ use discogs_xml_converter::pg_output::PgOutput;
 use discogs_xml_converter::writer::CsvOutput;
 use rayon::prelude::*;
 
-/// Convert Discogs XML data dumps to CSV files.
+/// Environment variable consulted by `import` when `--database-url` is omitted.
+const DATABASE_URL_ENV: &str = "DATABASE_URL_DISCOGS";
+
+/// Convert Discogs XML data dumps to CSV files or stream them to PostgreSQL.
 ///
-/// Produces CSV files compatible with discogs-cache's import_csv.py.
-/// Optionally filters to releases by artists in a library file.
-///
-/// Input can be a single releases XML file or a directory containing
-/// multiple XML dumps (artists.xml, labels.xml, releases.xml).
-/// When a directory is given, files are auto-detected by root element.
+/// Input can be a single XML file (releases, artists, labels, masters) or a
+/// directory containing multiple XML dumps. When a directory is given, files
+/// are auto-detected by root element.
 #[derive(Parser)]
 #[command(name = "discogs-xml-converter")]
 #[command(version, about)]
 struct Cli {
-    /// Path to Discogs XML file or directory containing XML dumps
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Convert Discogs XML to CSV files in `--data-dir`.
+    Build(BuildCmd),
+    /// Stream Discogs XML directly into PostgreSQL via COPY.
+    Import(ImportCmd),
+}
+
+#[derive(Args)]
+struct BuildCmd {
+    /// Path to Discogs XML file or directory containing XML dumps.
     input: PathBuf,
 
-    /// Output directory for CSV files
-    #[arg(long)]
-    output_dir: PathBuf,
+    #[command(flatten)]
+    build: ResumableBuildArgs,
 
-    /// Path to library_artists.txt for filtering
+    /// DEPRECATED: use `--data-dir` (alias retained for one release).
+    #[arg(long, hide = true)]
+    output_dir: Option<PathBuf>,
+
+    #[command(flatten)]
+    shared: SharedReleaseArgs,
+}
+
+#[derive(Args)]
+struct ImportCmd {
+    /// Path to Discogs XML file or directory containing XML dumps.
+    input: PathBuf,
+
+    #[command(flatten)]
+    db: DatabaseArgs,
+
+    #[command(flatten)]
+    import: ImportArgs,
+
+    /// DEPRECATED: use `--data-dir` for supplementary CSV outputs (alias retained for one release).
+    #[arg(long, hide = true)]
+    output_dir: Option<PathBuf>,
+
+    #[command(flatten)]
+    shared: SharedReleaseArgs,
+
+    /// Number of releases to buffer before flushing to PostgreSQL.
+    /// Larger values reduce per-COPY overhead but use more memory
+    /// (~100 bytes/release across the per-table buffers).
+    #[arg(long, default_value = "100000")]
+    batch_size: usize,
+}
+
+#[derive(Args)]
+struct SharedReleaseArgs {
+    /// Path to library_artists.txt for filtering.
     #[arg(long)]
     library_artists: Option<PathBuf>,
 
-    /// Maximum number of releases to process
+    /// Maximum number of releases to process.
     #[arg(long)]
     limit: Option<usize>,
 
-    /// Log progress every N releases
+    /// Log progress every N releases.
     #[arg(long, default_value = "100000")]
     progress_interval: usize,
+}
 
-    /// PostgreSQL connection URL for direct-to-database output.
-    /// When provided, releases are streamed directly into PostgreSQL
-    /// via COPY instead of being written to CSV files.
-    #[arg(long)]
-    database_url: Option<String>,
-
-    /// Number of releases to buffer before flushing to PostgreSQL.
-    /// Only used with --database-url. Larger values reduce per-COPY overhead
-    /// but use more memory (~100 bytes/release across 5 table buffers).
-    #[arg(long, default_value = "100000")]
-    batch_size: usize,
+/// Resolve the data directory, accepting the deprecated `--output-dir` alias
+/// with a stderr warning.
+fn resolve_data_dir(output_dir: Option<PathBuf>, data_dir: PathBuf) -> PathBuf {
+    if let Some(legacy) = output_dir {
+        eprintln!(
+            "warning: --output-dir is deprecated; use --data-dir (this alias will be removed in the next release)"
+        );
+        legacy
+    } else {
+        data_dir
+    }
 }
 
 /// Detect the XML type by reading the root element.
@@ -548,144 +598,241 @@ fn matches_filter(filter: &ArtistFilter, release: &discogs_xml_converter::model:
     }
 }
 
-fn main() -> Result<()> {
-    let _logger_guard = wxyc_etl::logger::init(wxyc_etl::logger::LoggerConfig {
-        repo: "discogs-xml-converter",
-        tool: "discogs-xml-converter",
-        sentry_dsn: None,
-        run_id: None,
+/// Resolved release-processing configuration shared between subcommands.
+struct RunConfig {
+    input: PathBuf,
+    data_dir: PathBuf,
+    library_artists: Option<PathBuf>,
+    limit: Option<usize>,
+    progress_interval: usize,
+    sink: ReleaseSink,
+}
+
+enum ReleaseSink {
+    Csv,
+    Pg {
+        database_url: String,
+        batch_size: usize,
+    },
+}
+
+fn build_config(cmd: BuildCmd) -> RunConfig {
+    let data_dir = resolve_data_dir(cmd.output_dir, cmd.build.data_dir);
+    if cmd.build.resume {
+        warn!(
+            "--resume is accepted for CLI parity but discogs-xml-converter is single-pass; \
+             the state file at {} will be ignored",
+            cmd.build.state_file.display()
+        );
+    }
+    RunConfig {
+        input: cmd.input,
+        data_dir,
+        library_artists: cmd.shared.library_artists,
+        limit: cmd.shared.limit,
+        progress_interval: cmd.shared.progress_interval,
+        sink: ReleaseSink::Csv,
+    }
+}
+
+fn import_config(cmd: ImportCmd) -> Result<RunConfig> {
+    let database_url = resolve_database_url(&cmd.db, DATABASE_URL_ENV)
+        .with_context(|| format!("resolve database URL for `import` ({})", DATABASE_URL_ENV))?;
+    let data_dir = resolve_data_dir(cmd.output_dir, cmd.import.data_dir);
+    if cmd.import.fresh {
+        info!("--fresh: truncating release tables before import");
+        truncate_release_tables(&database_url)?;
+    }
+    Ok(RunConfig {
+        input: cmd.input,
+        data_dir,
+        library_artists: cmd.shared.library_artists,
+        limit: cmd.shared.limit,
+        progress_interval: cmd.shared.progress_interval,
+        sink: ReleaseSink::Pg {
+            database_url,
+            batch_size: cmd.batch_size,
+        },
+    })
+}
+
+/// Truncate release-scoped tables before a `--fresh` import.
+///
+/// Children CASCADE off `release`, so a single TRUNCATE clears everything
+/// downstream and resets identity sequences.
+fn truncate_release_tables(database_url: &str) -> Result<()> {
+    let mut client = postgres::Client::connect(database_url, postgres::NoTls)
+        .with_context(|| format!("Failed to connect to PostgreSQL at {}", database_url))?;
+    client
+        .batch_execute("TRUNCATE TABLE release RESTART IDENTITY CASCADE")
+        .context("TRUNCATE release CASCADE failed")?;
+    Ok(())
+}
+
+fn run(cfg: RunConfig) -> Result<()> {
+    if cfg.input.is_dir() {
+        run_directory(cfg)
+    } else {
+        run_single_file(cfg)
+    }
+}
+
+fn run_directory(cfg: RunConfig) -> Result<()> {
+    let xml_files = scan_directory(&cfg.input)?;
+
+    // Start scanning releases early so the 57GB file read overlaps with
+    // artist/label processing. The bounded channel provides backpressure.
+    let scanner = xml_files.releases.as_ref().map(|releases_path| {
+        info!("Starting release scanner: {}", releases_path.display());
+        start_scanner(
+            releases_path.to_path_buf(),
+            cfg.limit,
+            cfg.progress_interval,
+        )
     });
 
-    let cli = Cli::parse();
-
-    if cli.input.is_dir() {
-        // Directory mode: scan for XML files and process in order
-        let xml_files = scan_directory(&cli.input)?;
-
-        // Start scanning releases early so the 57GB file read overlaps with
-        // artist/label processing. The bounded channel provides backpressure.
-        let scanner = xml_files.releases.as_ref().map(|releases_path| {
-            info!("Starting release scanner: {}", releases_path.display());
-            start_scanner(
-                releases_path.to_path_buf(),
-                cli.limit,
-                cli.progress_interval,
-            )
-        });
-
-        // Process artists and labels in parallel (independent files)
-        match (&xml_files.artists, &xml_files.labels) {
-            (Some(artists_path), Some(labels_path)) => {
-                std::thread::scope(|s| {
-                    let h1 = s.spawn(|| process_artists(artists_path, &cli.output_dir));
-                    let h2 = s.spawn(|| process_labels(labels_path, &cli.output_dir));
-                    h1.join().unwrap()?;
-                    h2.join().unwrap()?;
-                    Ok::<(), anyhow::Error>(())
-                })?;
-            }
-            (Some(artists_path), None) => {
-                process_artists(artists_path, &cli.output_dir)?;
-            }
-            (None, Some(labels_path)) => {
-                process_labels(labels_path, &cli.output_dir)?;
-            }
-            (None, None) => {}
+    match (&xml_files.artists, &xml_files.labels) {
+        (Some(artists_path), Some(labels_path)) => {
+            std::thread::scope(|s| {
+                let h1 = s.spawn(|| process_artists(artists_path, &cfg.data_dir));
+                let h2 = s.spawn(|| process_labels(labels_path, &cfg.data_dir));
+                h1.join().unwrap()?;
+                h2.join().unwrap()?;
+                Ok::<(), anyhow::Error>(())
+            })?;
         }
-
-        // Process masters (independent of artists/labels/releases)
-        if let Some(masters_path) = &xml_files.masters {
-            process_masters(masters_path, &cli.output_dir)?;
+        (Some(artists_path), None) => {
+            process_artists(artists_path, &cfg.data_dir)?;
         }
+        (None, Some(labels_path)) => {
+            process_labels(labels_path, &cfg.data_dir)?;
+        }
+        (None, None) => {}
+    }
 
-        // Load artist filter with optional alias enhancement
-        let filter = match &cli.library_artists {
-            Some(path) => {
-                let mut f = ArtistFilter::from_file(path)?;
-                info!("Loaded {} library artists from {}", f.len(), path.display());
+    if let Some(masters_path) = &xml_files.masters {
+        process_masters(masters_path, &cfg.data_dir)?;
+    }
 
-                // If artists.xml was processed, load aliases for enhanced filtering
-                let alias_csv = cli.output_dir.join("artist_alias.csv");
-                if alias_csv.exists() {
-                    let alias_count = f.load_aliases(&alias_csv)?;
-                    info!(
-                        "Loaded {} artist aliases for enhanced filtering",
-                        alias_count
-                    );
-                }
-                Some(f)
+    let filter = match &cfg.library_artists {
+        Some(path) => {
+            let mut f = ArtistFilter::from_file(path)?;
+            info!("Loaded {} library artists from {}", f.len(), path.display());
+
+            let alias_csv = cfg.data_dir.join("artist_alias.csv");
+            if alias_csv.exists() {
+                let alias_count = f.load_aliases(&alias_csv)?;
+                info!(
+                    "Loaded {} artist aliases for enhanced filtering",
+                    alias_count
+                );
             }
-            None => None,
-        };
+            Some(f)
+        }
+        None => None,
+    };
 
-        // Consume scanner batches (scanner has been reading ahead this whole time)
-        if let Some((rx, handle)) = scanner {
-            if let Some(ref db_url) = cli.database_url {
-                let mut output = PgOutput::new(db_url, cli.batch_size)?;
-                consume_releases(rx, handle, &mut output, &filter)?;
-                output.finish()?;
-            } else {
-                let mut output = CsvOutput::new(&cli.output_dir)?;
+    if let Some((rx, handle)) = scanner {
+        match &cfg.sink {
+            ReleaseSink::Pg {
+                database_url,
+                batch_size,
+            } => {
+                let mut output = PgOutput::new(database_url, *batch_size)?;
                 consume_releases(rx, handle, &mut output, &filter)?;
                 output.finish()?;
             }
-        } else {
-            warn!("No releases XML found in directory {}", cli.input.display());
+            ReleaseSink::Csv => {
+                let mut output = CsvOutput::new(&cfg.data_dir)?;
+                consume_releases(rx, handle, &mut output, &filter)?;
+                output.finish()?;
+            }
         }
-
-        drop(filter);
     } else {
-        // Single file mode: detect XML type, dispatch accordingly
-        let xml_type = detect_xml_type(&cli.input)?;
-        match xml_type.as_str() {
-            "masters" => {
-                process_masters(&cli.input, &cli.output_dir)?;
-                return Ok(());
-            }
-            "artists" => {
-                process_artists(&cli.input, &cli.output_dir)?;
-                return Ok(());
-            }
-            "labels" => {
-                process_labels(&cli.input, &cli.output_dir)?;
-                return Ok(());
-            }
-            _ => {} // Default: treat as releases (backward compatible)
+        warn!("No releases XML found in directory {}", cfg.input.display());
+    }
+
+    Ok(())
+}
+
+fn run_single_file(cfg: RunConfig) -> Result<()> {
+    let xml_type = detect_xml_type(&cfg.input)?;
+    match xml_type.as_str() {
+        "masters" => {
+            process_masters(&cfg.input, &cfg.data_dir)?;
+            return Ok(());
         }
+        "artists" => {
+            process_artists(&cfg.input, &cfg.data_dir)?;
+            return Ok(());
+        }
+        "labels" => {
+            process_labels(&cfg.input, &cfg.data_dir)?;
+            return Ok(());
+        }
+        _ => {} // Default: treat as releases
+    }
 
-        let filter = match &cli.library_artists {
-            Some(path) => {
-                let f = ArtistFilter::from_file(path)?;
-                info!("Loaded {} library artists from {}", f.len(), path.display());
-                Some(f)
-            }
-            None => None,
-        };
+    let filter = match &cfg.library_artists {
+        Some(path) => {
+            let f = ArtistFilter::from_file(path)?;
+            info!("Loaded {} library artists from {}", f.len(), path.display());
+            Some(f)
+        }
+        None => None,
+    };
 
-        if let Some(ref db_url) = cli.database_url {
-            let mut output = PgOutput::new(db_url, cli.batch_size)?;
+    match &cfg.sink {
+        ReleaseSink::Pg {
+            database_url,
+            batch_size,
+        } => {
+            let mut output = PgOutput::new(database_url, *batch_size)?;
             process_releases(
-                &cli.input,
+                &cfg.input,
                 &mut output,
                 &filter,
-                cli.limit,
-                cli.progress_interval,
+                cfg.limit,
+                cfg.progress_interval,
             )?;
             output.finish()?;
-        } else {
-            let mut output = CsvOutput::new(&cli.output_dir)?;
+        }
+        ReleaseSink::Csv => {
+            let mut output = CsvOutput::new(&cfg.data_dir)?;
             process_releases(
-                &cli.input,
+                &cfg.input,
                 &mut output,
                 &filter,
-                cli.limit,
-                cli.progress_interval,
+                cfg.limit,
+                cfg.progress_interval,
             )?;
             output.finish()?;
         }
     }
 
     Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let tool = match &cli.cmd {
+        Command::Build(_) => "discogs-xml-converter build",
+        Command::Import(_) => "discogs-xml-converter import",
+    };
+    let _logger_guard = wxyc_etl::logger::init(wxyc_etl::logger::LoggerConfig {
+        repo: "discogs-xml-converter",
+        tool,
+        sentry_dsn: None,
+        run_id: None,
+    });
+
+    // TODO: provision SENTRY_DSN in the runtime env (CI / deploy config) — see issue #33.
+
+    let cfg = match cli.cmd {
+        Command::Build(cmd) => build_config(cmd),
+        Command::Import(cmd) => import_config(cmd)?,
+    };
+    run(cfg)
 }
 
 #[cfg(test)]
@@ -952,14 +1099,14 @@ mod tests {
 
         // Sequential
         let seq_dir = tempfile::tempdir().unwrap();
-        process_artists(&artists_path, &seq_dir.path().to_path_buf()).unwrap();
-        process_labels(&labels_path, &seq_dir.path().to_path_buf()).unwrap();
+        process_artists(&artists_path, seq_dir.path()).unwrap();
+        process_labels(&labels_path, seq_dir.path()).unwrap();
 
         // Parallel
         let par_dir = tempfile::tempdir().unwrap();
         std::thread::scope(|s| {
-            let h1 = s.spawn(|| process_artists(&artists_path, &par_dir.path().to_path_buf()));
-            let h2 = s.spawn(|| process_labels(&labels_path, &par_dir.path().to_path_buf()));
+            let h1 = s.spawn(|| process_artists(&artists_path, par_dir.path()));
+            let h2 = s.spawn(|| process_labels(&labels_path, par_dir.path()));
             h1.join().unwrap().unwrap();
             h2.join().unwrap().unwrap();
         });

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -29,8 +29,9 @@ fn test_missing_artists_xml_in_directory_mode() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
+        .arg("build")
         .arg(input_dir.path().to_str().unwrap())
-        .arg("--output-dir")
+        .arg("--data-dir")
         .arg(output_dir.path().to_str().unwrap())
         .assert()
         .success();
@@ -91,8 +92,9 @@ fn test_release_with_many_artists_no_oom() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
+        .arg("build")
         .arg(xml_path.to_str().unwrap())
-        .arg("--output-dir")
+        .arg("--data-dir")
         .arg(output_dir.path().to_str().unwrap())
         .assert()
         .success();
@@ -112,13 +114,14 @@ fn test_release_with_many_artists_no_oom() {
 }
 
 #[test]
-fn test_help() {
+fn test_help_lists_subcommands() {
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Convert Discogs XML"));
+        .stdout(predicate::str::contains("build"))
+        .stdout(predicate::str::contains("import"));
 }
 
 #[test]
@@ -130,8 +133,9 @@ fn test_emits_json_logs_without_sentry_dsn() {
 
     let output = StdCommand::new(&bin)
         .env_remove("SENTRY_DSN")
+        .arg("build")
         .arg(fixture_path("releases_fixture.xml").to_str().unwrap())
-        .arg("--output-dir")
+        .arg("--data-dir")
         .arg(dir.path().to_str().unwrap())
         .output()
         .unwrap();
@@ -157,7 +161,30 @@ fn test_emits_json_logs_without_sentry_dsn() {
 }
 
 #[test]
-fn test_missing_required_args() {
+fn test_build_help_shows_data_dir_and_resume() {
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args(["build", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--data-dir"))
+        .stdout(predicate::str::contains("--state-file"))
+        .stdout(predicate::str::contains("--resume"));
+}
+
+#[test]
+fn test_import_help_shows_database_url_and_fresh() {
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args(["import", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--database-url"))
+        .stdout(predicate::str::contains("--fresh"));
+}
+
+#[test]
+fn test_no_subcommand_fails() {
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
         .assert()
@@ -165,12 +192,43 @@ fn test_missing_required_args() {
 }
 
 #[test]
-fn test_missing_output_dir() {
+fn test_build_requires_input() {
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(fixture_path("single_release.xml").to_str().unwrap())
+        .arg("build")
         .assert()
         .failure();
+}
+
+#[test]
+fn test_import_without_database_url_or_env_fails() {
+    // Clear the env var so the fallback doesn't kick in.
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .env_remove("DATABASE_URL_DISCOGS")
+        .args([
+            "import",
+            fixture_path("single_release.xml").to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("DATABASE_URL_DISCOGS"));
+}
+
+#[test]
+fn test_import_uses_database_url_env_fallback() {
+    // The env var resolves but the URL is unreachable; the failure must come
+    // from the connection attempt, not from the missing-flag path.
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .env("DATABASE_URL_DISCOGS", "postgresql://127.0.0.1:1/never")
+        .args([
+            "import",
+            fixture_path("single_release.xml").to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("DATABASE_URL_DISCOGS").not());
 }
 
 #[test]
@@ -179,9 +237,12 @@ fn test_end_to_end() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(fixture_path("releases_fixture.xml").to_str().unwrap())
-        .arg("--output-dir")
-        .arg(dir.path().to_str().unwrap())
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -198,15 +259,8 @@ fn test_end_to_end() {
         assert!(path.exists(), "{} should exist", filename);
     }
 
-    // Check row counts
-    let count_records = |filename: &str| -> usize {
-        let path = dir.path().join(filename);
-        let mut rdr = csv::Reader::from_path(&path).unwrap();
-        rdr.records().count()
-    };
-
-    // releases_fixture.xml has 16 releases, all with artists (none skipped)
-    assert_eq!(count_records("release.csv"), 16);
+    let mut rdr = csv::Reader::from_path(dir.path().join("release.csv")).unwrap();
+    assert_eq!(rdr.records().count(), 16);
 }
 
 #[test]
@@ -215,11 +269,14 @@ fn test_with_library_artists_filter() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(fixture_path("releases_fixture.xml").to_str().unwrap())
-        .arg("--output-dir")
-        .arg(dir.path().to_str().unwrap())
-        .arg("--library-artists")
-        .arg(fixture_path("library_artists.txt").to_str().unwrap())
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--library-artists",
+            fixture_path("library_artists.txt").to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -239,11 +296,14 @@ fn test_limit() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(fixture_path("releases_fixture.xml").to_str().unwrap())
-        .arg("--output-dir")
-        .arg(dir.path().to_str().unwrap())
-        .arg("--limit")
-        .arg("5")
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--limit",
+            "5",
+        ])
         .assert()
         .success();
 
@@ -258,9 +318,12 @@ fn test_gzipped_input() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(fixture_path("releases_fixture.xml.gz").to_str().unwrap())
-        .arg("--output-dir")
-        .arg(dir.path().to_str().unwrap())
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml.gz").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -271,11 +334,9 @@ fn test_gzipped_input() {
 
 #[test]
 fn test_directory_input() {
-    // Create a temp directory with symlinks to fixture XML files
     let input_dir = tempfile::tempdir().unwrap();
     let output_dir = tempfile::tempdir().unwrap();
 
-    // Copy fixture files to simulate a directory of XML dumps
     std::fs::copy(
         fixture_path("releases_fixture.xml"),
         input_dir.path().join("releases.xml"),
@@ -294,17 +355,17 @@ fn test_directory_input() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(input_dir.path().to_str().unwrap())
-        .arg("--output-dir")
-        .arg(output_dir.path().to_str().unwrap())
+        .args([
+            "build",
+            input_dir.path().to_str().unwrap(),
+            "--data-dir",
+            output_dir.path().to_str().unwrap(),
+        ])
         .assert()
         .success();
 
-    // Check release CSV files exist (same as single file mode)
     assert!(output_dir.path().join("release.csv").exists());
     assert!(output_dir.path().join("release_artist.csv").exists());
-
-    // Check artist and label CSV files exist
     assert!(
         output_dir.path().join("artist_alias.csv").exists(),
         "artist_alias.csv should be created"
@@ -318,14 +379,10 @@ fn test_directory_input() {
         "label_hierarchy.csv should be created"
     );
 
-    // Check content of label_hierarchy.csv
     let mut rdr = csv::Reader::from_path(output_dir.path().join("label_hierarchy.csv")).unwrap();
     let records: Vec<csv::StringRecord> = rdr.records().map(|r| r.unwrap()).collect();
-    // 4 labels have parents: Parlophone->EMI, Capitol Records->EMI,
-    // Matador Records->Beggars Group, 4AD->Beggars Group
     assert_eq!(records.len(), 4, "Expected 4 label hierarchy entries");
 
-    // Check releases were processed
     let mut rdr = csv::Reader::from_path(output_dir.path().join("release.csv")).unwrap();
     let count = rdr.records().count();
     assert_eq!(count, 16, "Expected 16 releases (no filter)");
@@ -333,22 +390,15 @@ fn test_directory_input() {
 
 #[test]
 fn test_directory_input_with_alias_filtering() {
-    // Test that alias-enhanced filtering works end-to-end.
-    // The releases_fixture.xml has a release credited to "Field, The" (id 8).
-    // The library_artists.txt has "The Field".
-    // Without aliases, "Field, The" != "The Field" (no match).
-    // We'll create an artists.xml that maps artist_id 8 to alias "The Field".
     let input_dir = tempfile::tempdir().unwrap();
     let output_dir = tempfile::tempdir().unwrap();
 
-    // Copy releases fixture
     std::fs::copy(
         fixture_path("releases_fixture.xml"),
         input_dir.path().join("releases.xml"),
     )
     .unwrap();
 
-    // Create a custom artists.xml that maps artist_id 8 to alias "The Field"
     let artists_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <artists>
   <artist>
@@ -364,16 +414,17 @@ fn test_directory_input_with_alias_filtering() {
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(input_dir.path().to_str().unwrap())
-        .arg("--output-dir")
-        .arg(output_dir.path().to_str().unwrap())
-        .arg("--library-artists")
-        .arg(fixture_path("library_artists.txt").to_str().unwrap())
+        .args([
+            "build",
+            input_dir.path().to_str().unwrap(),
+            "--data-dir",
+            output_dir.path().to_str().unwrap(),
+            "--library-artists",
+            fixture_path("library_artists.txt").to_str().unwrap(),
+        ])
         .assert()
         .success();
 
-    // Without alias: 9 matches. With alias: "Field, The" now matches via
-    // alias "The Field" -> should be 10.
     let mut rdr = csv::Reader::from_path(output_dir.path().join("release.csv")).unwrap();
     let count = rdr.records().count();
     assert_eq!(
@@ -383,31 +434,51 @@ fn test_directory_input_with_alias_filtering() {
 }
 
 #[test]
-fn test_single_file_backward_compatible() {
-    // Verify single file mode still works identically
+fn test_single_file_build_mode() {
     let dir = tempfile::tempdir().unwrap();
 
     Command::cargo_bin("discogs-xml-converter")
         .unwrap()
-        .arg(fixture_path("releases_fixture.xml").to_str().unwrap())
-        .arg("--output-dir")
-        .arg(dir.path().to_str().unwrap())
-        .arg("--library-artists")
-        .arg(fixture_path("library_artists.txt").to_str().unwrap())
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--library-artists",
+            fixture_path("library_artists.txt").to_str().unwrap(),
+        ])
         .assert()
         .success();
 
-    // Same result as before: 9 filtered releases
     let mut rdr = csv::Reader::from_path(dir.path().join("release.csv")).unwrap();
     let count = rdr.records().count();
     assert_eq!(
         count, 9,
-        "Single file mode should produce same results as before"
+        "Single-file mode should produce same results as before"
     );
 
-    // artist_alias.csv should NOT exist in single file mode
     assert!(
         !dir.path().join("artist_alias.csv").exists(),
         "artist_alias.csv should not be created in single file mode"
     );
+}
+
+#[test]
+fn test_deprecated_output_dir_alias_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--output-dir",
+            dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("--output-dir is deprecated"));
+
+    let mut rdr = csv::Reader::from_path(dir.path().join("release.csv")).unwrap();
+    assert_eq!(rdr.records().count(), 16);
 }


### PR DESCRIPTION
## Summary

- Split the single-command CLI into `build` (XML → CSV) and `import` (XML → PostgreSQL) subcommands matching the wxyc-etl cache-builder convention.
- Flatten `wxyc_etl::cli::{DatabaseArgs, ResumableBuildArgs, ImportArgs}` and resolve the database URL via `resolve_database_url(args, "DATABASE_URL_DISCOGS")` so the env var works as a fallback.
- Retain `--output-dir` as a deprecated alias for `--data-dir` (one release; stderr warning). `--fresh` truncates `release` CASCADE before importing. `--resume` is accepted for parity but is a no-op (this tool is single-pass).
- Update README.md and CLAUDE.md with the new invocation examples.
- Bump the `wxyc-etl` git dep from the `etl-unification/3a-combined-deps` branch to `main`, which now carries the `cli` module.

## Acceptance criteria

- [x] `<tool> --help` lists `build` and `import`; both subcommand `--help` outputs include the convention's flags
- [x] `DATABASE_URL_DISCOGS` env var works as a `--database-url` fallback for `import`
- [x] `--output-dir` deprecation alias works and emits a stderr warning
- [x] Local CI: `cargo test`, `cargo build --release`, `cargo fmt --check` all green
- [x] README + CLAUDE.md updated with new examples

## Test plan

- [x] `cargo test` (unit + CLI + oracle + pg_direct_import)
- [x] `cargo build --release`
- [x] `cargo fmt --check`
- [ ] Verify GitHub Actions CI passes after push

## Tracking

- Closes #34
- Parent epic: WXYC/wxyc-etl#45 — Standardize cache-builder CLI shape
- Blocked by: WXYC/wxyc-etl#51 (merged) — Add `wxyc_etl::cli` shared helpers