### PR TITLE
Pin wxyc-etl to crates.io 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,7 +3210,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wxyc-etl"
 version = "0.1.0"
-source = "git+https://github.com/WXYC/wxyc-etl.git?branch=main#c958a51563cb69c645a5cda7d127e1a964d1c702"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e0a1f3339c2fb633a75b09d65fd022c4b1328f2965750097fa60c626930140"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ memchr = "2"
 rayon = "1.10"
 postgres = "0.19"
 itoa = "1"
-wxyc-etl = { git = "https://github.com/WXYC/wxyc-etl.git", branch = "main", package = "wxyc-etl" }
+wxyc-etl = "0.1.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Switches `wxyc-etl` from `{ git = "...", branch = "main" }` to the published crate `wxyc-etl = "0.1.0"`.
- Refreshes `Cargo.lock` to resolve `wxyc-etl 0.1.0` from crates.io.
- CI workflow already had no `wxyc-etl` checkout step; no workflow changes needed.

## Test plan

- [x] `cargo build`
- [x] `cargo build --release`
- [x] `cargo test`
- [ ] CI green on push

Closes #35

Parent: WXYC/wxyc-etl#46