### PR TITLE
feat: add --xml-type flag to bypass per-file root-element detection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,15 @@ struct SharedReleaseArgs {
     /// Log progress every N releases.
     #[arg(long, default_value = "100000")]
     progress_interval: usize,
+
+    /// Skip per-file root-element detection and treat the input as the given
+    /// dump type. Required when the input is a stream-only source (named pipe,
+    /// process substitution): the auto-detector opens the file, reads the
+    /// root element, and closes — closing a FIFO read end terminates the
+    /// upstream writer before the real scan opens it. With this flag, the
+    /// input is opened exactly once.
+    #[arg(long, value_parser = ["releases", "artists", "labels", "masters"])]
+    xml_type: Option<String>,
 }
 
 /// Resolve the data directory, accepting the deprecated `--output-dir` alias
@@ -605,6 +614,9 @@ struct RunConfig {
     library_artists: Option<PathBuf>,
     limit: Option<usize>,
     progress_interval: usize,
+    /// When set, skips per-file root-element auto-detection and treats the
+    /// input as the given dump type. See SharedReleaseArgs::xml_type.
+    xml_type: Option<String>,
     sink: ReleaseSink,
 }
 
@@ -631,6 +643,7 @@ fn build_config(cmd: BuildCmd) -> RunConfig {
         library_artists: cmd.shared.library_artists,
         limit: cmd.shared.limit,
         progress_interval: cmd.shared.progress_interval,
+        xml_type: cmd.shared.xml_type,
         sink: ReleaseSink::Csv,
     }
 }
@@ -649,6 +662,7 @@ fn import_config(cmd: ImportCmd) -> Result<RunConfig> {
         library_artists: cmd.shared.library_artists,
         limit: cmd.shared.limit,
         progress_interval: cmd.shared.progress_interval,
+        xml_type: cmd.shared.xml_type,
         sink: ReleaseSink::Pg {
             database_url,
             batch_size: cmd.batch_size,
@@ -756,7 +770,13 @@ fn run_directory(cfg: RunConfig) -> Result<()> {
 }
 
 fn run_single_file(cfg: RunConfig) -> Result<()> {
-    let xml_type = detect_xml_type(&cfg.input)?;
+    // Caller-supplied --xml-type bypasses auto-detection. detect_xml_type
+    // opens the input, reads the root element, and closes — that close-on-FIFO
+    // breaks the upstream writer, so streaming inputs MUST set xml_type.
+    let xml_type = match &cfg.xml_type {
+        Some(t) => t.clone(),
+        None => detect_xml_type(&cfg.input)?,
+    };
     match xml_type.as_str() {
         "masters" => {
             process_masters(&cfg.input, &cfg.data_dir)?;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -313,6 +313,49 @@ fn test_limit() {
 }
 
 #[test]
+fn test_xml_type_flag_processes_as_releases() {
+    // --xml-type=releases lets the caller bypass the per-file root-element
+    // detection. This matters when the input is a stream-only source (named
+    // pipe / process substitution): detect_xml_type opens the file, reads
+    // the root element, and closes. On a FIFO, that close kills any upstream
+    // writer (e.g. a backgrounded `curl -o FIFO`) with SIGPIPE before the
+    // real scan ever opens the file. With --xml-type, the detection open is
+    // skipped and the FIFO is opened exactly once.
+    let dir = tempfile::tempdir().unwrap();
+
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--xml-type",
+            "releases",
+        ])
+        .assert()
+        .success();
+
+    let mut rdr = csv::Reader::from_path(dir.path().join("release.csv")).unwrap();
+    let count = rdr.records().count();
+    assert_eq!(count, 16, "release.csv should have all 16 fixture releases");
+}
+
+#[test]
+fn test_xml_type_flag_rejects_invalid_value() {
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--xml-type",
+            "nonsense",
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
 fn test_gzipped_input() {
     let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## Summary
- \`detect_xml_type\` opens the input, reads the root element, then closes. The actual scan re-opens the file. On a regular file this is harmless; on a FIFO the close kills the upstream writer (e.g. \`curl -o FIFO &\`) before the scan opens it.
- Hit on EC2 today (2026-05-06): \`curl: (23) Failure writing output to destination\` within seconds of the converter \"opening\" the FIFO. After tracing it to the open-twice pattern, this PR adds \`--xml-type=releases|artists|labels|masters\` so the operator can skip auto-detection. \`run_single_file\` reads the flag first; \`detect_xml_type\` is only called when the flag is absent.
- discogs-etl's cron-driven rebuild will set \`--xml-type=releases\`, restoring the FIFO architecture and avoiding the ~10 GB on-disk spool that overflowed the EC2 root volume.

## Test plan
- [x] New CLI test \`test_xml_type_flag_processes_as_releases\` confirms the flag is accepted and produces the expected release.csv (16 rows from fixture).
- [x] New CLI test \`test_xml_type_flag_rejects_invalid_value\` confirms clap value_parser rejects unknown types.
- [x] Full \`cargo test\` passes (113 + 8 + 1 + 20 + 7 + 8).
- [x] \`cargo fmt --check\` clean.
- [x] \`cargo clippy --release\` clean (test-only clippy warnings pre-existed on main).