### PR TITLE
feat: add --library-db pair-wise (artist, title) release filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Purpose-built Rust tool for converting Discogs XML data dumps to CSV files compa
 - `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` using `wxyc_etl::csv_writer::MultiCsvWriter` for 9 CSV files matching `import_csv.py` contract
 - `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; uses `wxyc_etl::pg::BatchCopier` for FK-ordered flush and `wxyc_etl::pg::copy` for COPY TEXT escaping; domain-specific post-import logic (artwork URLs, track counts, cache_metadata) remains local
 - `filter.rs` -- `ArtistFilter` HashSet-based artist name filtering with alias support; normalization delegates to `wxyc_etl::text::normalize_artist_name()`
+- `library_pairs.rs` -- `LibraryPairs` inverted index `{normalized_title -> set<normalized_artist>}` loaded from a SQLite `library.db`. Powers the `--library-db` pair-wise filter that narrows the converter's ~4M-release artist-only output to ~50K so the import fits Railway-sized destination DBs. Mirrors `discogs-etl/scripts/filter_csv.py::load_library_pairs`
 - `main.rs` -- CLI using clap derive with `build` / `import` subcommands; flattens `wxyc_etl::cli::{DatabaseArgs, ResumableBuildArgs, ImportArgs}` for the cache-builder convention; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer); output dispatch between CSV and PG sinks
 
 ### Parallel Processing Pipeline
@@ -70,7 +71,6 @@ cargo build --release   # produces target/release/discogs-xml-converter
 - `cargo clippy` for linting
 - Targets macOS ARM64 and Linux x86_64
 
-<<<<<<< HEAD
 ## Observability
 
 `main.rs` initializes `wxyc_etl::logger` at startup. Logs emit as one JSON object per line on stdout; panics and `tracing::error!` events forward to Sentry when `SENTRY_DSN` is set in the environment. Without a DSN, JSON logging still works and Sentry stays inactive.
@@ -82,16 +82,22 @@ Sentry tags applied to every event:
 - `step` -- set per-span via `tracing::info_span!("...", step = "...")`
 
 TODO: provision `SENTRY_DSN` in the environments that invoke this tool (discogs-etl GitHub Actions workflow + any manual cache rebuild scripts on EC2). DSN provisioning is tracked separately from this wireup.
-=======
+
 ## CLI shape (cache-builder convention)
 
 The tool exposes two subcommands that compose shared `wxyc_etl::cli` argument groups:
 
-- `discogs-xml-converter build <input> [--data-dir DIR] [--state-file FILE] [--resume] [--library-artists FILE] [--limit N]` — convert XML to CSV files in `--data-dir` (defaults to `./data`). `--resume` is accepted for parity with other cache builders but is currently a no-op (this tool is single-pass).
-- `discogs-xml-converter import <input> --database-url URL [--data-dir DIR] [--fresh] [--batch-size N]` — stream releases directly into PostgreSQL via COPY. `--database-url` falls back to the `DATABASE_URL_DISCOGS` environment variable. `--fresh` runs `TRUNCATE release ... CASCADE` before importing.
+- `discogs-xml-converter build <input> [--data-dir DIR] [--state-file FILE] [--resume] [--library-artists FILE | --library-db FILE] [--limit N]` — convert XML to CSV files in `--data-dir` (defaults to `./data`). `--resume` is accepted for parity with other cache builders but is currently a no-op (this tool is single-pass).
+- `discogs-xml-converter import <input> --database-url URL [--data-dir DIR] [--fresh] [--batch-size N] [--library-artists FILE | --library-db FILE]` — stream releases directly into PostgreSQL via COPY. `--database-url` falls back to the `DATABASE_URL_DISCOGS` environment variable. `--fresh` runs `TRUNCATE release ... CASCADE` before importing.
 
 `--output-dir` is accepted as a deprecation alias for `--data-dir` (with a stderr warning) for one release. The deprecation alias is enforced in tests; remove it in the next breaking-change cycle once all callers (`discogs-etl`'s `run_pipeline.py`) have migrated.
->>>>>>> 695744b (Migrate to standardized cache-builder CLI)
+
+### Filter modes
+
+`--library-artists` and `--library-db` are mutually exclusive. Both run in the streaming scanner — releases are tested as they're parsed, so filtered-out releases never enter the writer's buffers.
+
+- `--library-artists FILE` keeps any release whose credited artist (main or extra) appears in `library_artists.txt`. In directory mode, an `artist_alias.csv` companion enables alias-aware matching by `artist_id`. Yields ~4M releases on a current Discogs dump — too large for Railway-sized destination DBs (overflows during `COPY release_artist`).
+- `--library-db FILE` keeps any release whose `(artist, title)` pair appears in the SQLite `library.db` (the `library` table's `artist`, `title` columns). Both sides are normalized via `wxyc_etl::text::to_match_form` so diacritics don't matter. Yields ~50K releases — the size that fits Railway-sized targets and is what `rebuild-cache.sh` runs in production. The pair-filter implementation lives in `src/library_pairs.rs` and is parity-tested against `discogs-etl/scripts/filter_csv.py::filter_csvs_by_pairs` in `tests/parity_test.rs` (opt-in via `DISCOGS_ETL_REPO`).
 
 ## Key Design Decisions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "pretty_assertions",
  "quick-xml",
  "rayon",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ memchr = "2"
 rayon = "1.10"
 postgres = "0.19"
 itoa = "1"
+rusqlite = { version = "0.31", features = ["bundled"] }
 wxyc-etl = "^0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod filter;
 pub mod label_model;
 pub mod label_parser;
 pub mod label_writer;
+pub mod library_pairs;
 pub mod master_model;
 pub mod master_parser;
 pub mod master_writer;

--- a/src/library_pairs.rs
+++ b/src/library_pairs.rs
@@ -1,0 +1,347 @@
+//! Pair-wise (artist, title) filter loaded from a SQLite `library.db`.
+//!
+//! Used by the monthly Discogs cache rebuild on EC2. The artist-only filter
+//! still keeps ~4M releases — the rebuild's destination Postgres can't hold
+//! that volume. Narrowing to releases whose `(artist, title)` pair appears
+//! in the WXYC library brings it to ~50K.
+//!
+//! Data layout: an inverted index `{normalized_title -> set<normalized_artist>}`
+//! so the streaming scanner does one lookup per candidate release keyed by
+//! title, then a small set probe per credited artist. Mirrors the Python
+//! reference at `discogs-etl/scripts/filter_csv.py::load_library_pairs`.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::filter::normalize_artist;
+
+/// Normalize a release title for pair matching.
+///
+/// Same shape as [`crate::filter::normalize_artist`] (NFKD + strip combining
+/// characters + lowercase + trim) so a Discogs title with diacritics matches
+/// a library title without them, and vice versa. Delegates to
+/// [`wxyc_etl::text::to_match_form`] for parity with every other WXYC tool.
+pub fn normalize_title(title: &str) -> String {
+    wxyc_etl::text::to_match_form(title)
+}
+
+/// Inverted-index of WXYC library `(artist, title)` pairs.
+#[derive(Debug)]
+pub struct LibraryPairs {
+    pairs: HashMap<String, HashSet<String>>,
+}
+
+impl LibraryPairs {
+    /// Load every `(artist, title)` row from `library.db`'s `library` table
+    /// into the inverted index. Empty `artist` or `title` rows are skipped
+    /// (matches the Python reference); duplicates collapse via the set.
+    pub fn from_db(path: &Path) -> Result<Self> {
+        let conn =
+            rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+                .with_context(|| format!("Failed to open library.db at {}", path.display()))?;
+
+        let mut stmt = conn
+            .prepare("SELECT artist, title FROM library")
+            .context("library.db is missing the expected `library(artist, title)` table")?;
+
+        let mut pairs: HashMap<String, HashSet<String>> = HashMap::new();
+        let rows = stmt.query_map([], |row| {
+            let artist: String = row.get(0)?;
+            let title: String = row.get(1)?;
+            Ok((artist, title))
+        })?;
+
+        for row in rows {
+            let (artist, title) = row?;
+            if artist.is_empty() || title.is_empty() {
+                continue;
+            }
+            let n_title = normalize_title(&title);
+            let n_artist = normalize_artist(&artist);
+            if n_title.is_empty() || n_artist.is_empty() {
+                continue;
+            }
+            pairs.entry(n_title).or_default().insert(n_artist);
+        }
+
+        Ok(LibraryPairs { pairs })
+    }
+
+    /// Check whether `title` paired with any of `artist_names` appears in the
+    /// library. Both sides are normalized before comparison; the inputs may
+    /// be the raw values pulled from a Discogs `<release>`.
+    pub fn matches<'a, I>(&self, title: &str, artist_names: I) -> bool
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let n_title = normalize_title(title);
+        let library_artists = match self.pairs.get(&n_title) {
+            Some(set) => set,
+            None => return false,
+        };
+        artist_names
+            .into_iter()
+            .any(|name| library_artists.contains(&normalize_artist(name)))
+    }
+
+    /// Number of distinct normalized titles in the index.
+    pub fn len(&self) -> usize {
+        self.pairs.len()
+    }
+
+    /// Whether the index has no entries.
+    pub fn is_empty(&self) -> bool {
+        self.pairs.is_empty()
+    }
+
+    /// Total `(title, artist)` pairs spanned by the index. Diagnostic only.
+    pub fn pair_count(&self) -> usize {
+        self.pairs.values().map(|s| s.len()).sum()
+    }
+
+    /// Look up the artist set for a normalized title. Test-only convenience.
+    #[cfg(test)]
+    pub fn artists_for_title(&self, normalized_title: &str) -> Option<&HashSet<String>> {
+        self.pairs.get(normalized_title)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn make_library_db(path: &Path, rows: &[(&str, &str)]) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE library (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT,\
+                artist TEXT NOT NULL,\
+                title TEXT NOT NULL,\
+                format TEXT\
+             );",
+        )
+        .unwrap();
+        let mut stmt = conn
+            .prepare("INSERT INTO library (artist, title) VALUES (?1, ?2)")
+            .unwrap();
+        for (artist, title) in rows {
+            stmt.execute(rusqlite::params![artist, title]).unwrap();
+        }
+    }
+
+    // ---- normalize_title -------------------------------------------------
+
+    #[test]
+    fn normalize_title_lowercase() {
+        assert_eq!(normalize_title("Confield"), "confield");
+    }
+
+    #[test]
+    fn normalize_title_trims_spaces() {
+        assert_eq!(normalize_title("  Confield  "), "confield");
+    }
+
+    #[test]
+    fn normalize_title_all_caps() {
+        assert_eq!(normalize_title("CONFIELD"), "confield");
+    }
+
+    #[test]
+    fn normalize_title_empty() {
+        assert_eq!(normalize_title(""), "");
+    }
+
+    #[test]
+    fn normalize_title_diacritics() {
+        assert_eq!(
+            normalize_title("Pequeña Vertigem de Amor"),
+            "pequena vertigem de amor"
+        );
+        assert_eq!(
+            normalize_title("Père Ubu's Métal Box"),
+            "pere ubu's metal box"
+        );
+    }
+
+    /// The whole point of the pair-filter is that titles normalize identically
+    /// to artist names so a diacritic-mismatched library and Discogs row still
+    /// collide. Pin that.
+    #[test]
+    fn normalize_title_parity_with_artist() {
+        let cases = [
+            "PAINLESS",
+            "Métal Box",
+            "  On Your Own Love Again  ",
+            "Pequeña Vertigem de Amor",
+        ];
+        for s in cases {
+            assert_eq!(normalize_title(s), normalize_artist(s), "mismatch for {s}");
+        }
+    }
+
+    // ---- LibraryPairs::from_db ------------------------------------------
+
+    #[test]
+    fn from_db_returns_inverted_index_keyed_by_title() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("library.db");
+        make_library_db(
+            &db,
+            &[
+                ("Autechre", "Confield"),
+                ("Autechre", "Amber"),
+                ("Stereolab", "Aluminum Tunes"),
+            ],
+        );
+
+        let pairs = LibraryPairs::from_db(&db).unwrap();
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(
+            pairs.artists_for_title("confield"),
+            Some(&HashSet::from(["autechre".to_string()]))
+        );
+        assert_eq!(
+            pairs.artists_for_title("aluminum tunes"),
+            Some(&HashSet::from(["stereolab".to_string()]))
+        );
+    }
+
+    #[test]
+    fn from_db_collapses_duplicate_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("library.db");
+        make_library_db(
+            &db,
+            &[
+                ("Stereolab", "Aluminum Tunes"),
+                ("Stereolab", "Aluminum Tunes"),
+                ("Stereolab", "Aluminum Tunes"),
+            ],
+        );
+
+        let pairs = LibraryPairs::from_db(&db).unwrap();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs.pair_count(), 1);
+    }
+
+    #[test]
+    fn from_db_groups_multiple_artists_under_same_title() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("library.db");
+        make_library_db(
+            &db,
+            &[
+                ("Various Artists", "Compilation"),
+                ("Stereolab", "Compilation"),
+            ],
+        );
+
+        let pairs = LibraryPairs::from_db(&db).unwrap();
+        let set = pairs.artists_for_title("compilation").unwrap();
+        assert_eq!(
+            set,
+            &HashSet::from(["various artists".to_string(), "stereolab".to_string()])
+        );
+    }
+
+    #[test]
+    fn from_db_normalizes_diacritics_on_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("library.db");
+        make_library_db(&db, &[("Nilüfer Yanya", "PAINLESS")]);
+
+        let pairs = LibraryPairs::from_db(&db).unwrap();
+        assert_eq!(
+            pairs.artists_for_title("painless"),
+            Some(&HashSet::from(["nilufer yanya".to_string()]))
+        );
+    }
+
+    #[test]
+    fn from_db_skips_empty_artist_or_title_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("library.db");
+        make_library_db(
+            &db,
+            &[
+                ("", "Confield"),      // empty artist
+                ("Autechre", ""),      // empty title
+                ("   ", "  "),         // whitespace-only normalize to empty
+                ("Autechre", "Amber"), // valid
+            ],
+        );
+
+        let pairs = LibraryPairs::from_db(&db).unwrap();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(
+            pairs.artists_for_title("amber"),
+            Some(&HashSet::from(["autechre".to_string()]))
+        );
+    }
+
+    #[test]
+    fn from_db_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("nonexistent.db");
+        let err = LibraryPairs::from_db(&db).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("library.db"), "unexpected error: {msg}");
+    }
+
+    // ---- LibraryPairs::matches ------------------------------------------
+
+    fn pairs_from(rows: &[(&str, &str)]) -> LibraryPairs {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("library.db");
+        make_library_db(&db, rows);
+        LibraryPairs::from_db(&db).unwrap()
+    }
+
+    #[test]
+    fn matches_exact_pair() {
+        let pairs = pairs_from(&[("Autechre", "Confield")]);
+        assert!(pairs.matches("Confield", ["Autechre"]));
+    }
+
+    #[test]
+    fn matches_normalizes_diacritics_on_release_side() {
+        // Library has the diacritic-stripped form; the Discogs release
+        // arrives with diacritics. Both sides must match.
+        let pairs = pairs_from(&[("Nilufer Yanya", "PAINLESS")]);
+        assert!(pairs.matches("PAINLESS", ["Nilüfer Yanya"]));
+    }
+
+    #[test]
+    fn matches_normalizes_diacritics_on_library_side() {
+        // Library entry has diacritics, Discogs side doesn't.
+        let pairs = pairs_from(&[("Nilüfer Yanya", "PAINLESS")]);
+        assert!(pairs.matches("PAINLESS", ["Nilufer Yanya"]));
+    }
+
+    #[test]
+    fn matches_rejects_when_title_not_in_library() {
+        let pairs = pairs_from(&[("Autechre", "Confield")]);
+        assert!(!pairs.matches("Some Other Album", ["Autechre"]));
+    }
+
+    #[test]
+    fn matches_rejects_when_title_matches_but_artist_doesnt() {
+        let pairs = pairs_from(&[("Autechre", "Confield")]);
+        assert!(!pairs.matches("Confield", ["Some Other Band"]));
+    }
+
+    #[test]
+    fn matches_kept_when_any_credited_artist_matches() {
+        let pairs = pairs_from(&[("Field, The", "From Here We Go Sublime")]);
+        assert!(pairs.matches("From Here We Go Sublime", ["Some Producer", "Field, The"]));
+    }
+
+    #[test]
+    fn matches_empty_title_excluded() {
+        let pairs = pairs_from(&[("Autechre", "Confield")]);
+        assert!(!pairs.matches("", ["Autechre"]));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use discogs_xml_converter::artist_writer::ArtistCsvOutput;
 use discogs_xml_converter::filter::ArtistFilter;
 use discogs_xml_converter::label_parser::parse_labels;
 use discogs_xml_converter::label_writer::LabelCsvOutput;
+use discogs_xml_converter::library_pairs::LibraryPairs;
 use discogs_xml_converter::master_parser::parse_masters;
 use discogs_xml_converter::master_writer::MasterCsvOutput;
 use discogs_xml_converter::output::ReleaseOutput;
@@ -88,9 +89,21 @@ struct ImportCmd {
 
 #[derive(Args)]
 struct SharedReleaseArgs {
-    /// Path to library_artists.txt for filtering.
-    #[arg(long)]
+    /// Path to library_artists.txt for artist-only filtering.
+    /// Mutually exclusive with `--library-db`.
+    #[arg(long, conflicts_with = "library_db")]
     library_artists: Option<PathBuf>,
+
+    /// Path to a SQLite `library.db` for pair-wise `(artist, title)` filtering.
+    /// Releases whose title is in the library AND whose credited artist
+    /// matches one of the library's artists for that title are kept.
+    /// Mutually exclusive with `--library-artists`.
+    ///
+    /// The artist-only filter retains ~4M releases on a full Discogs dump,
+    /// which overflows small destination volumes during `COPY release_artist`.
+    /// The pair filter narrows that to ~50K, fitting Railway-sized targets.
+    #[arg(long)]
+    library_db: Option<PathBuf>,
 
     /// Maximum number of releases to process.
     #[arg(long)]
@@ -306,7 +319,7 @@ fn consume_releases(
     rx: crossbeam_channel::Receiver<ReleaseBatch>,
     scanner_handle: std::thread::JoinHandle<Result<usize>>,
     output: &mut impl ReleaseOutput,
-    filter: &Option<ArtistFilter>,
+    filter: &Option<ReleaseFilter>,
 ) -> Result<()> {
     let mut written = 0usize;
     let mut filtered = 0usize;
@@ -397,7 +410,7 @@ fn consume_releases(
 fn process_releases(
     path: &Path,
     output: &mut impl ReleaseOutput,
-    filter: &Option<ArtistFilter>,
+    filter: &Option<ReleaseFilter>,
     limit: Option<usize>,
     progress_interval: usize,
 ) -> Result<()> {
@@ -583,27 +596,93 @@ fn scan_reader<R: Read>(
     Ok(count)
 }
 
-/// Check if a release matches the artist filter.
+/// Combined release filter. Either the artist-only HashSet or the pair-wise
+/// `(artist, title)` index from a `library.db`. Set at startup based on which
+/// of `--library-artists` / `--library-db` was passed.
+enum ReleaseFilter {
+    Artists(ArtistFilter),
+    Pairs(LibraryPairs),
+}
+
+/// Build the configured release filter from the resolved CLI args.
 ///
-/// Uses alias-enhanced matching (by artist_id) when aliases are loaded,
-/// otherwise falls back to canonical name matching.
-fn matches_filter(filter: &ArtistFilter, release: &discogs_xml_converter::model::Release) -> bool {
-    if filter.has_aliases() {
-        let artist_ids: Vec<(u64, &str)> = release
-            .artists
-            .iter()
-            .chain(release.extra_artists.iter())
-            .map(|a| (a.artist_id, a.name.as_str()))
-            .collect();
-        filter.matches_any_with_ids(&artist_ids)
-    } else {
-        let names: Vec<&str> = release
-            .artists
-            .iter()
-            .chain(release.extra_artists.iter())
-            .map(|a| a.name.as_str())
-            .collect();
-        filter.matches_any(names)
+/// `data_dir_for_aliases` should be `Some(data_dir)` in directory mode, where
+/// the converter's own `artist_alias.csv` output is available, and `None` in
+/// single-file streaming mode (no companion CSVs exist yet). Aliases only
+/// apply to artist-only filtering; pair-mode ignores them.
+///
+/// `--library-artists` and `--library-db` are mutually exclusive at the clap
+/// layer; this returns `None` when neither is set.
+fn build_filter(
+    cfg: &RunConfig,
+    data_dir_for_aliases: Option<&Path>,
+) -> Result<Option<ReleaseFilter>> {
+    if let Some(path) = &cfg.library_db {
+        let pairs = LibraryPairs::from_db(path)?;
+        info!(
+            "Loaded {} library titles spanning {} (artist, title) pairs from {}",
+            pairs.len(),
+            pairs.pair_count(),
+            path.display()
+        );
+        return Ok(Some(ReleaseFilter::Pairs(pairs)));
+    }
+
+    if let Some(path) = &cfg.library_artists {
+        let mut f = ArtistFilter::from_file(path)?;
+        info!("Loaded {} library artists from {}", f.len(), path.display());
+
+        if let Some(data_dir) = data_dir_for_aliases {
+            let alias_csv = data_dir.join("artist_alias.csv");
+            if alias_csv.exists() {
+                let alias_count = f.load_aliases(&alias_csv)?;
+                info!(
+                    "Loaded {} artist aliases for enhanced filtering",
+                    alias_count
+                );
+            }
+        }
+        return Ok(Some(ReleaseFilter::Artists(f)));
+    }
+
+    Ok(None)
+}
+
+/// Check if a release matches the configured filter.
+///
+/// In artist mode, uses alias-enhanced matching (by artist_id) when aliases
+/// are loaded, otherwise falls back to canonical name matching. In pair mode,
+/// looks up the release title in the library's inverted index and checks
+/// whether any credited artist appears in that title's set.
+fn matches_filter(filter: &ReleaseFilter, release: &discogs_xml_converter::model::Release) -> bool {
+    match filter {
+        ReleaseFilter::Artists(f) => {
+            if f.has_aliases() {
+                let artist_ids: Vec<(u64, &str)> = release
+                    .artists
+                    .iter()
+                    .chain(release.extra_artists.iter())
+                    .map(|a| (a.artist_id, a.name.as_str()))
+                    .collect();
+                f.matches_any_with_ids(&artist_ids)
+            } else {
+                let names: Vec<&str> = release
+                    .artists
+                    .iter()
+                    .chain(release.extra_artists.iter())
+                    .map(|a| a.name.as_str())
+                    .collect();
+                f.matches_any(names)
+            }
+        }
+        ReleaseFilter::Pairs(p) => {
+            let names = release
+                .artists
+                .iter()
+                .chain(release.extra_artists.iter())
+                .map(|a| a.name.as_str());
+            p.matches(&release.title, names)
+        }
     }
 }
 
@@ -612,6 +691,7 @@ struct RunConfig {
     input: PathBuf,
     data_dir: PathBuf,
     library_artists: Option<PathBuf>,
+    library_db: Option<PathBuf>,
     limit: Option<usize>,
     progress_interval: usize,
     /// When set, skips per-file root-element auto-detection and treats the
@@ -641,6 +721,7 @@ fn build_config(cmd: BuildCmd) -> RunConfig {
         input: cmd.input,
         data_dir,
         library_artists: cmd.shared.library_artists,
+        library_db: cmd.shared.library_db,
         limit: cmd.shared.limit,
         progress_interval: cmd.shared.progress_interval,
         xml_type: cmd.shared.xml_type,
@@ -660,6 +741,7 @@ fn import_config(cmd: ImportCmd) -> Result<RunConfig> {
         input: cmd.input,
         data_dir,
         library_artists: cmd.shared.library_artists,
+        library_db: cmd.shared.library_db,
         limit: cmd.shared.limit,
         progress_interval: cmd.shared.progress_interval,
         xml_type: cmd.shared.xml_type,
@@ -728,23 +810,7 @@ fn run_directory(cfg: RunConfig) -> Result<()> {
         process_masters(masters_path, &cfg.data_dir)?;
     }
 
-    let filter = match &cfg.library_artists {
-        Some(path) => {
-            let mut f = ArtistFilter::from_file(path)?;
-            info!("Loaded {} library artists from {}", f.len(), path.display());
-
-            let alias_csv = cfg.data_dir.join("artist_alias.csv");
-            if alias_csv.exists() {
-                let alias_count = f.load_aliases(&alias_csv)?;
-                info!(
-                    "Loaded {} artist aliases for enhanced filtering",
-                    alias_count
-                );
-            }
-            Some(f)
-        }
-        None => None,
-    };
+    let filter = build_filter(&cfg, Some(&cfg.data_dir))?;
 
     if let Some((rx, handle)) = scanner {
         match &cfg.sink {
@@ -793,14 +859,9 @@ fn run_single_file(cfg: RunConfig) -> Result<()> {
         _ => {} // Default: treat as releases
     }
 
-    let filter = match &cfg.library_artists {
-        Some(path) => {
-            let f = ArtistFilter::from_file(path)?;
-            info!("Loaded {} library artists from {}", f.len(), path.display());
-            Some(f)
-        }
-        None => None,
-    };
+    // Single-file mode has no companion artist_alias.csv to draw from, so
+    // alias-enhanced matching is unavailable here.
+    let filter = build_filter(&cfg, None)?;
 
     match &cfg.sink {
         ReleaseSink::Pg {
@@ -892,7 +953,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("artists.txt");
         std::fs::write(&path, "Autechre\nNilüfer Yanya\n").unwrap();
-        let filter = ArtistFilter::from_file(&path).unwrap();
+        let filter = ReleaseFilter::Artists(ArtistFilter::from_file(&path).unwrap());
 
         // Main artist matches
         let release = make_release(vec![(1, "Autechre")], vec![]);
@@ -920,8 +981,9 @@ mod tests {
         )
         .unwrap();
 
-        let mut filter = ArtistFilter::from_file(&lib_path).unwrap();
-        filter.load_aliases(&alias_path).unwrap();
+        let mut artist_filter = ArtistFilter::from_file(&lib_path).unwrap();
+        artist_filter.load_aliases(&alias_path).unwrap();
+        let filter = ReleaseFilter::Artists(artist_filter);
 
         // Canonical name doesn't match, but alias does via artist_id
         let release = make_release(vec![(123, "Sun Ra")], vec![]);
@@ -930,6 +992,52 @@ mod tests {
         // Unknown artist doesn't match
         let release = make_release(vec![(999, "Unknown")], vec![]);
         assert!(!matches_filter(&filter, &release));
+    }
+
+    #[test]
+    fn test_matches_filter_with_pairs() {
+        // Build a library.db with two pairs and verify matches_filter
+        // dispatches to LibraryPairs::matches.
+        use rusqlite::Connection;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("library.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE library (\
+                id INTEGER PRIMARY KEY AUTOINCREMENT,\
+                artist TEXT NOT NULL,\
+                title TEXT NOT NULL,\
+                format TEXT\
+             );\
+             INSERT INTO library (artist, title) VALUES \
+                ('Autechre', 'Confield'),\
+                ('Stereolab', 'Aluminum Tunes');",
+        )
+        .unwrap();
+        drop(conn);
+        let pairs = LibraryPairs::from_db(&db_path).unwrap();
+        let filter = ReleaseFilter::Pairs(pairs);
+
+        // Title in library, artist in library's set for that title
+        let mut release = make_release(vec![(1, "Autechre")], vec![]);
+        release.title = "Confield".to_string();
+        assert!(matches_filter(&filter, &release));
+
+        // Title in library but artist isn't credited on this release
+        let mut release = make_release(vec![(99, "Unknown")], vec![]);
+        release.title = "Confield".to_string();
+        assert!(!matches_filter(&filter, &release));
+
+        // Title not in library
+        let mut release = make_release(vec![(1, "Autechre")], vec![]);
+        release.title = "Some Other Album".to_string();
+        assert!(!matches_filter(&filter, &release));
+
+        // Diacritic mismatch on artist still matches via normalization
+        let mut release = make_release(vec![(2, "Stereolab")], vec![]);
+        release.title = "ALUMINUM TUNES".to_string();
+        assert!(matches_filter(&filter, &release));
     }
 
     fn fixture_path(name: &str) -> PathBuf {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -312,6 +312,132 @@ fn test_limit() {
     assert_eq!(count, 5, "Expected 5 releases with --limit 5");
 }
 
+/// Build a small `library.db` with the supplied `(artist, title)` rows for
+/// pair-filter integration tests. Returns the path to the file rooted in
+/// `dir`. Uses the canonical schema produced by `wxyc-export-to-sqlite`.
+fn make_test_library_db(dir: &std::path::Path, rows: &[(&str, &str)]) -> PathBuf {
+    let path = dir.join("library.db");
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE library (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT,\
+            artist TEXT NOT NULL,\
+            title TEXT NOT NULL,\
+            format TEXT\
+         );",
+    )
+    .unwrap();
+    {
+        let mut stmt = conn
+            .prepare("INSERT INTO library (artist, title) VALUES (?1, ?2)")
+            .unwrap();
+        for (artist, title) in rows {
+            stmt.execute(rusqlite::params![artist, title]).unwrap();
+        }
+    }
+    drop(conn);
+    path
+}
+
+#[test]
+fn test_with_library_db_pair_filter() {
+    // Exercises the new `--library-db` mode end-to-end through the CLI.
+    // The library.db keeps only:
+    //   - (Autechre, Confield)        -> matches releases 1001, 1002, 1003
+    //   - (Nilüfer Yanya, PAINLESS)   -> matches release 6001 (diacritic case)
+    //   - (Wrong Artist, Amber)       -> excludes release 3001 (title in DB
+    //                                    but artist on the release doesn't
+    //                                    match the library set for that title)
+    //   - (Autechre, Tri Repetae) is intentionally OMITTED so release 4001
+    //     is excluded even though its artist appears in the library.
+    let dir = tempfile::tempdir().unwrap();
+    let lib = tempfile::tempdir().unwrap();
+    let library_db = make_test_library_db(
+        lib.path(),
+        &[
+            ("Autechre", "Confield"),
+            ("Nilüfer Yanya", "PAINLESS"),
+            ("Wrong Artist", "Amber"),
+        ],
+    );
+
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--library-db",
+            library_db.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let mut rdr = csv::Reader::from_path(dir.path().join("release.csv")).unwrap();
+    let id_idx = rdr
+        .headers()
+        .unwrap()
+        .iter()
+        .position(|h| h == "id")
+        .unwrap();
+    let mut ids: Vec<u64> = rdr
+        .records()
+        .map(|r| r.unwrap()[id_idx].parse().unwrap())
+        .collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![1001, 1002, 1003, 6001],
+        "pair-filter should keep exactly the 4 releases whose (artist, title) appears in library.db"
+    );
+}
+
+#[test]
+fn test_library_db_and_library_artists_are_mutually_exclusive() {
+    // clap should reject a combo of both flags before any work begins.
+    let dir = tempfile::tempdir().unwrap();
+    let lib = tempfile::tempdir().unwrap();
+    let library_db = make_test_library_db(lib.path(), &[("Autechre", "Confield")]);
+
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--library-artists",
+            fixture_path("library_artists.txt").to_str().unwrap(),
+            "--library-db",
+            library_db.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("library-artists").or(predicate::str::contains("library-db")),
+        );
+}
+
+#[test]
+fn test_library_db_missing_file_fails_clearly() {
+    let dir = tempfile::tempdir().unwrap();
+
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            dir.path().to_str().unwrap(),
+            "--library-db",
+            "/nonexistent/library.db",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("library.db"));
+}
+
 #[test]
 fn test_xml_type_flag_processes_as_releases() {
     // --xml-type=releases lets the caller bypass the per-file root-element

--- a/tests/parity_test.rs
+++ b/tests/parity_test.rs
@@ -1,0 +1,157 @@
+//! Cross-implementation parity for the pair-wise (artist, title) filter.
+//!
+//! Runs the Rust converter's `--library-db` mode against `releases_fixture.xml`
+//! and runs Python `discogs-etl/scripts/filter_csv.py --library-db` against
+//! the converter's *unfiltered* output, then asserts both yield the same set
+//! of `release.id`s. This pins the two implementations together so the
+//! converter can replace `run_pipeline.py --pair-filter` without silently
+//! drifting on edge cases (diacritics, multi-artist releases, etc.).
+//!
+//! The test is opt-in via the `DISCOGS_ETL_REPO` env var pointing at a local
+//! checkout of `WXYC/discogs-etl` with its `.venv` populated. It skips
+//! gracefully when unset, so `cargo test` on a fresh laptop without the
+//! sibling repo still passes.
+#![allow(deprecated)] // Command::cargo_bin deprecation
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn make_library_db(dir: &Path, rows: &[(&str, &str)]) -> PathBuf {
+    let path = dir.join("library.db");
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE library (\
+            id INTEGER PRIMARY KEY AUTOINCREMENT,\
+            artist TEXT NOT NULL,\
+            title TEXT NOT NULL,\
+            format TEXT\
+         );",
+    )
+    .unwrap();
+    {
+        let mut stmt = conn
+            .prepare("INSERT INTO library (artist, title) VALUES (?1, ?2)")
+            .unwrap();
+        for (artist, title) in rows {
+            stmt.execute(rusqlite::params![artist, title]).unwrap();
+        }
+    }
+    drop(conn);
+    path
+}
+
+fn read_release_ids(release_csv: &Path) -> Vec<u64> {
+    let mut rdr = csv::Reader::from_path(release_csv).unwrap();
+    let id_idx = rdr
+        .headers()
+        .unwrap()
+        .iter()
+        .position(|h| h == "id")
+        .unwrap();
+    let mut ids: Vec<u64> = rdr
+        .records()
+        .map(|r| r.unwrap()[id_idx].parse().unwrap())
+        .collect();
+    ids.sort();
+    ids
+}
+
+#[test]
+fn pair_filter_matches_python_implementation() {
+    let etl_repo = match std::env::var("DISCOGS_ETL_REPO") {
+        Ok(p) if !p.is_empty() => PathBuf::from(p),
+        _ => {
+            eprintln!(
+                "skipping parity test: set DISCOGS_ETL_REPO to a local discogs-etl \
+                 checkout (with .venv populated) to run"
+            );
+            return;
+        }
+    };
+    let python = etl_repo.join(".venv/bin/python");
+    let filter_script = etl_repo.join("scripts/filter_csv.py");
+    if !python.exists() || !filter_script.exists() {
+        eprintln!(
+            "skipping parity test: missing {} or {}",
+            python.display(),
+            filter_script.display()
+        );
+        return;
+    }
+
+    // Library entries chosen to exercise: exact matches, diacritic mismatches
+    // both directions, multi-artist credits, and a title-only false-positive
+    // candidate (Amber-by-wrong-artist) that the pair filter must drop.
+    let lib_dir = tempfile::tempdir().unwrap();
+    let library_db = make_library_db(
+        lib_dir.path(),
+        &[
+            ("Autechre", "Confield"),
+            ("Autechre", "Tri Repetae"),
+            ("Nilufer Yanya", "PAINLESS"),
+            ("Wrong Artist", "Amber"),
+            ("Field, The", "From Here We Go Sublime"),
+        ],
+    );
+
+    // Path A: Rust converter applies --library-db itself.
+    let rust_out = tempfile::tempdir().unwrap();
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            rust_out.path().to_str().unwrap(),
+            "--library-db",
+            library_db.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let rust_ids = read_release_ids(&rust_out.path().join("release.csv"));
+
+    // Path B: Rust converter writes unfiltered CSVs; Python filter_csv.py
+    // applies --library-db over them in place.
+    let py_out = tempfile::tempdir().unwrap();
+    Command::cargo_bin("discogs-xml-converter")
+        .unwrap()
+        .args([
+            "build",
+            fixture_path("releases_fixture.xml").to_str().unwrap(),
+            "--data-dir",
+            py_out.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let py_status = std::process::Command::new(&python)
+        .arg(&filter_script)
+        .arg("--library-db")
+        .arg(&library_db)
+        .arg(py_out.path())
+        .arg(py_out.path())
+        .status()
+        .expect("python filter_csv.py failed to launch");
+    assert!(
+        py_status.success(),
+        "python filter_csv.py exited with non-zero status: {py_status}"
+    );
+    let py_ids = read_release_ids(&py_out.path().join("release.csv"));
+
+    assert!(
+        !rust_ids.is_empty(),
+        "parity test is meaningless if both sides are empty"
+    );
+    assert_eq!(
+        rust_ids, py_ids,
+        "Rust pair-filter and Python filter_csv.py disagree on which releases to keep"
+    );
+}


### PR DESCRIPTION
Closes #45.

## Summary

- Add `--library-db <PATH>` to the converter, mutually exclusive with `--library-artists`. Loads an inverted-index `{normalized_title → set<normalized_artist>}` from a SQLite `library.db` and keeps only releases whose title appears in the library and whose credited artist matches one of the library's artists for that title.
- The artist-only filter retains ~4M releases on the current Discogs monthly dump and overflows Railway-sized destination volumes during `COPY release_artist`. The pair filter narrows to ~50K, which is what `rebuild-cache.sh` will run in production.
- New `src/library_pairs.rs` mirrors `discogs-etl/scripts/filter_csv.py::load_library_pairs`. Normalization on both sides delegates to `wxyc_etl::text::to_match_form` so diacritics don't matter (`Nilüfer Yanya` ↔ `Nilufer Yanya`).
- `matches_filter` now dispatches via a `ReleaseFilter::{Artists, Pairs}` enum so the two filter modes share one entry point and one set of integration tests in the streaming pipeline.

## Tests

181 tests pass across 7 binaries (`cargo test`), `cargo fmt --check` is clean, `cargo clippy --all-targets` introduces no new warnings (5 pre-existing warnings remain in `parser.rs` tests).

- 19 unit tests for `library_pairs`: load, dedup, multi-artist titles, diacritic normalization, empty-row skip, missing-file error.
- 1 unit test for `matches_filter` dispatch into the pair branch (incl. diacritic-mismatched release-side artist).
- 3 CLI integration tests in `tests/cli_tests.rs`: end-to-end pair filter (asserts the exact set of kept release ids), clap rejection when both flags are passed, clear error on missing `library.db`.
- Opt-in parity test in `tests/parity_test.rs` (gated on `DISCOGS_ETL_REPO`): runs the Rust pair-filter and the Python `filter_csv.py --library-db` over the same fixture and asserts identical kept-release-id sets. Verified locally — both implementations agreed on the 6 expected releases.

## Doc / housekeeping

- `CLAUDE.md` documents the new module and the `Filter modes` subsection.
- Resolved pre-existing unresolved git conflict markers in `CLAUDE.md` left over from the cache-builder CLI migration. Both halves of the conflict (Observability + CLI shape) were valid and now sit in their own sections.

## Test plan

- [x] `cargo test` — 181 passing
- [x] `DISCOGS_ETL_REPO=/path/to/discogs-etl cargo test --test parity_test` — passing
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` — clean for new code
- [ ] CI: clippy / fmt / unit / integration jobs on push