### PR TITLE
deps: bump wxyc-etl ^0.2 → 0.3.0 (E3 step 5b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Purpose-built Rust tool for converting Discogs XML data dumps to CSV files compa
 - `output.rs` -- `ReleaseOutput` trait abstracting over output targets (CSV or PostgreSQL)
 - `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` using `wxyc_etl::csv_writer::MultiCsvWriter` for 9 CSV files matching `import_csv.py` contract
 - `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; uses `wxyc_etl::pg::BatchCopier` for FK-ordered flush and `wxyc_etl::pg::copy` for COPY TEXT escaping; domain-specific post-import logic (artwork URLs, track counts, cache_metadata) remains local
-- `filter.rs` -- `ArtistFilter` HashSet-based artist name filtering with alias support; normalization delegates to `wxyc_etl::text::normalize_artist_name()`
+- `filter.rs` -- `ArtistFilter` HashSet-based artist name filtering with alias support; normalization delegates to `wxyc_etl::text::to_match_form()`
 - `library_pairs.rs` -- `LibraryPairs` inverted index `{normalized_title -> set<normalized_artist>}` loaded from a SQLite `library.db`. Powers the `--library-db` pair-wise filter that narrows the converter's ~4M-release artist-only output to ~50K so the import fits Railway-sized destination DBs. Mirrors `discogs-etl/scripts/filter_csv.py::load_library_pairs`
 - `main.rs` -- CLI using clap derive with `build` / `import` subcommands; flattens `wxyc_etl::cli::{DatabaseArgs, ResumableBuildArgs, ImportArgs}` for the cache-builder convention; parallel release processing pipeline (scanner thread + rayon worker pool + sequential writer); output dispatch between CSV and PG sinks
 
@@ -101,7 +101,7 @@ The tool exposes two subcommands that compose shared `wxyc_etl::cli` argument gr
 
 ## Key Design Decisions
 
-- Artist normalization delegates to `wxyc_etl::text::normalize_artist_name()`, the shared implementation that all WXYC ETL repos use for normalization parity. Parity tests in `filter.rs` verify equivalence.
+- Artist normalization delegates to `wxyc_etl::text::to_match_form()`, the shared implementation that all WXYC ETL repos use for normalization parity. Parity tests in `filter.rs` verify equivalence.
 - Releases with no `<artists>` are skipped (not written to any CSV)
 - Format string: single format uses name; qty > 1 prefixes with `{qty}x`; multiple formats are comma-separated
 - Track sequence is 1-indexed position in the `<tracklist>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,9 +3218,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f6e6cda194702938a1b28276dc9df4d780c229ce491fb8c4e1fbdd3a4591f5"
+checksum = "e9f4f32d293cb6ab6d935ebfb343dd0581f0e2592c69e85612c78c05a171339b"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.10"
 postgres = "0.19"
 itoa = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }
-wxyc-etl = "^0.2"
+wxyc-etl = "0.3.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- Bumps `wxyc-etl` pin from `^0.2` to `0.3.0`, pulling in the cross-cache-identity normalizers (`to_identity_match_form` family) per [library-hook-canonicalization-plan §3.3.1 step 5](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md).
- The deprecated `normalize_artist_name` was already removed in d42173c; this PR also catches two stale references in `CLAUDE.md` that still pointed at the old name.

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace --lib` (132 unit) passes
- [x] `cargo test --workspace --tests` (all integration tiers) passes
- [x] `grep -r "normalize_artist_name" .` returns no matches in code or docs

Closes #46
Refs WXYC/wxyc-etl#73 (E3 step 5b)