### PR TITLE
Pin reusable workflow refs to gha/v1

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -14,9 +14,10 @@ on:
 
 jobs:
   drift:
-    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 41a18c5c0a92d129ec4b575827b6874196bfb7591e4bdf237a918a5da2de7b66
       package-version: '0.12.0'
+      wxyc-shared-ref: gha/v1
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pins reusable workflow refs from `@main` to the new `gha/v1` stability tags on `wxyc-shared` / `wxyc-etl`, and passes the matching `*-ref` input so the inner script checkout in each reusable workflow stays pinned (default was `main`).

## Why

Before this PR, a push to `wxyc-shared/main` or `wxyc-etl/main` would cascade into this repo's CI with this repo's secrets. The new `gha/v1` stability tags provide a pin-able ref. Tag policy: `gha/v1` moves for non-breaking updates; `gha/v2` for breaking changes.

## Project

Part of [GitHub Actions Supply-Chain Hardening](https://github.com/orgs/WXYC/projects/31), Phase 2.

## Test plan

- [ ] Reusable-workflow jobs still pass after merge.