### PR TITLE
release.yml: use Swatinem/rust-cache@v2 for cargo cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,12 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        # Matches the cache pattern in .github/workflows/ci.yml so cold-start
+        # behavior is consistent across both workflows. Swatinem handles
+        # cargo-workspace specifics (rustc version in the key, target/
+        # exclusions for incompatible artifacts) that the hand-rolled
+        # actions/cache@v4 approach doesn't.
+        uses: Swatinem/rust-cache@v2
 
       - name: Build release binary
         run: cargo build --release --target x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Summary

Replace the hand-rolled `actions/cache@v4` step in `.github/workflows/release.yml` with `Swatinem/rust-cache@v2`, matching the cache pattern already used in `ci.yml`.

## Why

The release workflow added in #52 cached `~/.cargo/registry`, `~/.cargo/git`, and `target/` keyed on `Cargo.lock` only. Swatinem/rust-cache handles cargo-workspace caching more robustly:

- Includes rustc version in the cache key so a toolchain bump invalidates correctly.
- Excludes the build script outputs and other artifacts that are unsafe to cache.
- Matches the existing `ci.yml` pattern, so cold-start behavior across both workflows is consistent.

## Scope

Single-file diff. No functional change to what's published — just the caching mechanics under the build step. Cache will rebuild from scratch on the first workflow run after merge; subsequent runs hit the new cache.

## Related

- #52 — original PR that added `release.yml`