### PR TITLE
artist_writer: split name variations into their own CSV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Purpose-built Rust tool for converting Discogs XML data dumps to CSV files compa
 - `model.rs` -- Data structures mirroring Discogs XML `<release>` elements; implements `wxyc_etl::pg::ImageRef` for `ReleaseImage`
 - `parser.rs` -- Pull-based XML parser using `quick-xml`, supports plain and gzipped input; `parse_release_from_bytes()` enables per-release parsing for the parallel pipeline
 - `output.rs` -- `ReleaseOutput` trait abstracting over output targets (CSV or PostgreSQL)
-- `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` using `wxyc_etl::csv_writer::MultiCsvWriter` for 9 CSV files matching `import_csv.py` contract
+- `writer.rs` -- `CsvOutput` implementation of `ReleaseOutput` using `wxyc_etl::csv_writer::MultiCsvWriter` for 9 CSV files matching `import_csv.py` contract. The separate `artist_writer.rs` produces the four artist-side CSVs (artist, artist_alias, artist_name_variation, artist_member)
 - `pg_output.rs` -- `PgOutput` implementation of `ReleaseOutput` for direct-to-PostgreSQL streaming via COPY; uses `wxyc_etl::pg::BatchCopier` for FK-ordered flush and `wxyc_etl::pg::copy` for COPY TEXT escaping; domain-specific post-import logic (artwork URLs, track counts, cache_metadata) remains local
 - `filter.rs` -- `ArtistFilter` HashSet-based artist name filtering with alias support; normalization delegates to `wxyc_etl::text::to_match_form()`
 - `library_pairs.rs` -- `LibraryPairs` inverted index `{normalized_title -> set<normalized_artist>}` loaded from a SQLite `library.db`. Powers the `--library-db` pair-wise filter that narrows the converter's ~4M-release artist-only output to ~50K so the import fits Railway-sized destination DBs. Mirrors `discogs-etl/scripts/filter_csv.py::load_library_pairs`

--- a/src/artist_writer.rs
+++ b/src/artist_writer.rs
@@ -1,9 +1,15 @@
 //! CSV output writer for Discogs artist data.
 //!
-//! Writes 3 CSV files:
+//! Writes 4 CSV files:
 //! - artist.csv (artist_id, artist_name, profile)
-//! - artist_alias.csv (artist_id, artist_name, alias_name)
+//! - artist_alias.csv (artist_id, artist_name, alias_name) — Discogs `<aliases>` (alter egos)
+//! - artist_name_variation.csv (artist_id, name) — Discogs `<namevariations>` (spelling variants)
 //! - artist_member.csv (group_artist_id, group_name, member_artist_id, member_name)
+//!
+//! Aliases and name variations are distinct in Discogs and are stored in
+//! separate tables on the consumer side (`artist_alias` and
+//! `artist_name_variation`). Folding them into one CSV used to leave
+//! `artist_name_variation` empty after a rebuild — see WXYC/discogs-etl#215.
 
 use std::fs;
 use std::path::Path;
@@ -13,10 +19,11 @@ use csv::Writer;
 
 use crate::artist_model::Artist;
 
-/// Manages CSV writers for artist, alias, and member output.
+/// Manages CSV writers for artist, alias, name-variation, and member output.
 pub struct ArtistCsvOutput {
     artist: Writer<fs::File>,
     alias: Writer<fs::File>,
+    name_variation: Writer<fs::File>,
     member: Writer<fs::File>,
 }
 
@@ -36,6 +43,9 @@ impl ArtistCsvOutput {
         let mut alias = Self::create_writer(output_dir, "artist_alias.csv")?;
         alias.write_record(["artist_id", "artist_name", "alias_name"])?;
 
+        let mut name_variation = Self::create_writer(output_dir, "artist_name_variation.csv")?;
+        name_variation.write_record(["artist_id", "name"])?;
+
         let mut member = Self::create_writer(output_dir, "artist_member.csv")?;
         member.write_record([
             "group_artist_id",
@@ -47,6 +57,7 @@ impl ArtistCsvOutput {
         Ok(ArtistCsvOutput {
             artist,
             alias,
+            name_variation,
             member,
         })
     }
@@ -59,29 +70,22 @@ impl ArtistCsvOutput {
     }
 
     /// Write an artist's aliases, name variations, and members to CSV files.
-    ///
-    /// Both aliases and name variations are written to artist_alias.csv since
-    /// they serve the same purpose: alternate names an artist might be credited under.
     pub fn write_artist(&mut self, artist: &Artist) -> Result<()> {
         let id_str = artist.id.to_string();
 
-        // Write artist row (only if profile is non-empty)
         if !artist.profile.is_empty() {
             self.artist
                 .write_record([&id_str, &artist.name, &artist.profile])?;
         }
 
-        // Write name variations as aliases
         for nv in &artist.name_variations {
-            self.alias.write_record([&id_str, &artist.name, nv])?;
+            self.name_variation.write_record([&id_str, nv])?;
         }
 
-        // Write aliases
         for alias in &artist.aliases {
             self.alias.write_record([&id_str, &artist.name, alias])?;
         }
 
-        // Write members
         for member in &artist.members {
             self.member.write_record([
                 &id_str,
@@ -98,6 +102,7 @@ impl ArtistCsvOutput {
     pub fn flush(&mut self) -> Result<()> {
         self.artist.flush()?;
         self.alias.flush()?;
+        self.name_variation.flush()?;
         self.member.flush()?;
         Ok(())
     }
@@ -200,14 +205,75 @@ mod tests {
 
         let mut rdr = csv::Reader::from_path(dir.path().join("artist_alias.csv")).unwrap();
         let records: Vec<csv::StringRecord> = rdr.records().map(|r| r.unwrap()).collect();
-        // 2 name variations + 2 aliases = 4
-        assert_eq!(records.len(), 4);
+        // 2 aliases ONLY; name variations now land in artist_name_variation.csv.
+        assert_eq!(records.len(), 2);
         assert_eq!(&records[0][0], "123");
         assert_eq!(&records[0][1], "P. Diddy");
-        assert_eq!(&records[0][2], "P Diddy");
-        assert_eq!(&records[1][2], "Puff Daddy");
-        assert_eq!(&records[2][2], "Sean Combs");
-        assert_eq!(&records[3][2], "Diddy");
+        assert_eq!(&records[0][2], "Sean Combs");
+        assert_eq!(&records[1][2], "Diddy");
+    }
+
+    #[test]
+    fn test_write_artist_name_variations() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut output = ArtistCsvOutput::new(dir.path()).unwrap();
+        output.write_artist(&sample_artist()).unwrap();
+        output.flush().unwrap();
+
+        let mut rdr = csv::Reader::from_path(dir.path().join("artist_name_variation.csv")).unwrap();
+        let headers: Vec<String> = rdr
+            .headers()
+            .unwrap()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(headers, vec!["artist_id", "name"]);
+
+        let records: Vec<csv::StringRecord> = rdr.records().map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(&records[0][0], "123");
+        assert_eq!(&records[0][1], "P Diddy");
+        assert_eq!(&records[1][0], "123");
+        assert_eq!(&records[1][1], "Puff Daddy");
+    }
+
+    #[test]
+    fn test_name_variations_isolated_from_aliases() {
+        // Pin: name_variations and aliases must not cross-pollinate. If the
+        // converter ever folds them back together, the artist_name_variation
+        // table will silently stay empty on the consumer (WXYC/discogs-etl#215).
+        let dir = tempfile::tempdir().unwrap();
+        let mut output = ArtistCsvOutput::new(dir.path()).unwrap();
+        let artist = Artist {
+            id: 7,
+            name: "Solo".to_string(),
+            profile: String::new(),
+            name_variations: vec!["Solo (var)".to_string()],
+            aliases: vec![],
+            members: vec![],
+        };
+        output.write_artist(&artist).unwrap();
+        output.flush().unwrap();
+
+        let aliases: Vec<csv::StringRecord> =
+            csv::Reader::from_path(dir.path().join("artist_alias.csv"))
+                .unwrap()
+                .records()
+                .map(|r| r.unwrap())
+                .collect();
+        assert!(
+            aliases.is_empty(),
+            "name_variation must not leak into artist_alias"
+        );
+
+        let nvs: Vec<csv::StringRecord> =
+            csv::Reader::from_path(dir.path().join("artist_name_variation.csv"))
+                .unwrap()
+                .records()
+                .map(|r| r.unwrap())
+                .collect();
+        assert_eq!(nvs.len(), 1);
+        assert_eq!(&nvs[0][1], "Solo (var)");
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -42,21 +42,44 @@ impl ArtistFilter {
         })
     }
 
-    /// Load artist aliases from `artist_alias.csv`.
+    /// Load artist aliases from `artist_alias.csv` (Discogs `<aliases>`).
     ///
     /// Builds a lookup from artist_id to normalized alias names. When combined
     /// with `matches_any_with_ids()`, this enables matching releases where the
     /// credited artist is known by a different name in the library.
+    ///
+    /// The CSV is expected to have columns `artist_id, artist_name, alias_name`.
+    /// Use [`load_name_variations`] to load Discogs `<namevariations>` from
+    /// `artist_name_variation.csv` in the same way.
     pub fn load_aliases(&mut self, csv_path: &Path) -> anyhow::Result<usize> {
+        self.load_alt_names_csv(csv_path, 2)
+    }
+
+    /// Load artist name variations from `artist_name_variation.csv` (Discogs
+    /// `<namevariations>`).
+    ///
+    /// Same lookup contract as [`load_aliases`]: builds the artist_id→names
+    /// map used by `matches_any_with_ids`. Discogs distinguishes aliases
+    /// (alter egos) from namevariations (spelling variants); both contribute
+    /// to filter recall and live in the same in-memory map. The two CSV
+    /// shapes differ — alias rows have an extra `artist_name` column — so
+    /// the column index for the name is parameterised internally.
+    ///
+    /// The CSV is expected to have columns `artist_id, name`.
+    pub fn load_name_variations(&mut self, csv_path: &Path) -> anyhow::Result<usize> {
+        self.load_alt_names_csv(csv_path, 1)
+    }
+
+    fn load_alt_names_csv(&mut self, csv_path: &Path, name_col: usize) -> anyhow::Result<usize> {
         let mut rdr = csv::Reader::from_path(csv_path)?;
         let mut count = 0;
 
         for result in rdr.records() {
             let record = result?;
             let artist_id: u64 = record[0].parse().unwrap_or(0);
-            let alias_name = &record[2]; // alias_name column
+            let name = &record[name_col];
 
-            let normalized = normalize_artist(alias_name);
+            let normalized = normalize_artist(name);
             if !normalized.is_empty() {
                 self.aliases.entry(artist_id).or_default().push(normalized);
                 count += 1;
@@ -343,6 +366,38 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_load_name_variations_and_match() {
+        // Pre-split, namevariations were folded into artist_alias.csv and
+        // therefore contributed to filter recall. After the split (#215)
+        // they live in artist_name_variation.csv; the filter must keep
+        // that recall by loading both.
+        let dir = tempfile::tempdir().unwrap();
+
+        let lib_path = dir.path().join("artists.txt");
+        // Library credits the variation form.
+        fs::write(&lib_path, "Le Sony'r Ra\n").unwrap();
+
+        let nv_path = dir.path().join("artist_name_variation.csv");
+        fs::write(
+            &nv_path,
+            "artist_id,name\n\
+             123,Le Sony'r Ra\n\
+             123,Sonny Ra\n",
+        )
+        .unwrap();
+
+        let mut filter = ArtistFilter::from_file(&lib_path).unwrap();
+        let count = filter.load_name_variations(&nv_path).unwrap();
+        assert_eq!(count, 2);
+        assert!(filter.has_aliases());
+
+        // Canonical "Sun Ra" name does not match, but the variation does
+        // via artist_id lookup.
+        assert!(!filter.matches_any(["Sun Ra"].iter().copied()));
+        assert!(filter.matches_any_with_ids(&[(123, "Sun Ra")]));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1250,6 +1250,7 @@ mod tests {
         // Compare all output files
         for filename in &[
             "artist_alias.csv",
+            "artist_name_variation.csv",
             "artist_member.csv",
             "label_hierarchy.csv",
         ] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -641,6 +641,14 @@ fn build_filter(
                     alias_count
                 );
             }
+            let nv_csv = data_dir.join("artist_name_variation.csv");
+            if nv_csv.exists() {
+                let nv_count = f.load_name_variations(&nv_csv)?;
+                info!(
+                    "Loaded {} artist name variations for enhanced filtering",
+                    nv_count
+                );
+            }
         }
         return Ok(Some(ReleaseFilter::Artists(f)));
     }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -540,6 +540,10 @@ fn test_directory_input() {
         "artist_alias.csv should be created"
     );
     assert!(
+        output_dir.path().join("artist_name_variation.csv").exists(),
+        "artist_name_variation.csv should be created"
+    );
+    assert!(
         output_dir.path().join("artist_member.csv").exists(),
         "artist_member.csv should be created"
     );


### PR DESCRIPTION
## Summary

Discogs `<aliases>` (alter egos) and `<namevariations>` (spelling variants) are distinct on the source side and map to two separate tables on the consumer side: `artist_alias` and `artist_name_variation`. The converter previously folded both into a single `artist_alias.csv`, which left the `artist_name_variation` table empty after every monthly rebuild and forced LML's `search_artists_by_name` to query an empty table for its fuzzy-name path.

This PR is the converter half of the architecturally correct fix from [WXYC/discogs-etl#215](https://github.com/WXYC/discogs-etl/issues/215) (path C). The companion PR on discogs-etl adds the matching importer config so the new CSV lands in the `artist_name_variation` table on the rebuild path.

## Changes

- `ArtistCsvOutput` now writes a fourth file, `artist_name_variation.csv`, with `(artist_id, name)` columns. `artist_alias.csv` continues to receive Discogs `<aliases>` rows only.
- `ArtistFilter::load_name_variations` mirrors `load_aliases` against the new file so the `--library-artists` filter keeps its name-variation recall in the streaming scanner. The existing `test_directory_input_with_alias_filtering` integration case (which uses a `<namevariations>` fixture to test that "9 canonical + 1 via alias" path) still passes with the new wire-up in `main.rs`.

## Tests

- New unit: `test_write_artist_name_variations` — verifies headers + that name variations land in their own file.
- New unit: `test_name_variations_isolated_from_aliases` — pin that aliases and name variations cannot cross-pollinate again.
- Modified `test_write_artist_aliases` — was asserting 4 rows (NV + alias folded together); now asserts 2 rows (aliases only).
- New unit: `test_load_name_variations_and_match` — confirms the filter's name-variation recall after the split.
- All 184 tests pass (`cargo test`), `cargo fmt --check` clean.

## Test plan

- [x] Unit tests pass locally
- [x] Integration tests pass locally (existing namevariation-based filter test still finds the matching release)
- [x] `cargo build --release` succeeds
- [ ] CI green
- [ ] Land in lockstep with the discogs-etl importer PR before the next monthly rebuild

## Related

- WXYC/discogs-etl#215 — parent issue (path C)
- WXYC/discogs-etl#188 — current rebuild blocker; this isn't a blocker for #188 but does unblock the `artist_name_variation`-fed LML fuzzy-match path that the calibration workstream depends on