### PR TITLE
chore: bump wxyc-etl to 0.6.0; add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      wxyc:
+        patterns:
+          - "wxyc-*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,9 +3218,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f4f32d293cb6ab6d935ebfb343dd0581f0e2592c69e85612c78c05a171339b"
+checksum = "ef019673a0efa28a07fef1836af299c0d8a5988b3045980fd8a5a8fe353ecac7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.10"
 postgres = "0.19"
 itoa = "1"
 rusqlite = { version = "0.31", features = ["bundled"] }
-wxyc-etl = "0.3.0"
+wxyc-etl = "0.6.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Bump `wxyc-etl` from 0.3.0 to 0.6.0 to catch up to the current substrate.
- Add `.github/dependabot.yml` so future `wxyc-etl` bumps land here as weekly grouped PRs instead of accumulating drift again.

The wxyc-etl APIs this repo consumes (`text::to_match_form`, `pg::{BatchCopier, copy, ImageRef, extract_year, pick_artwork_url}`, `cli::{DatabaseArgs, ResumableBuildArgs, ImportArgs, resolve_database_url}`, `csv_writer::MultiCsvWriter`, `logger`) are unchanged at their public boundary across 0.3.0 → 0.6.0, so no code changes were needed.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test` — all unit + integration + oracle + parity + pg_direct_import suites pass
- [x] `cargo build --release` (covered by CI)
- [ ] CI green