### PR TITLE
feat(artist): extract <urls> + emit artist_url.csv

### DIFF
--- a/src/artist_model.rs
+++ b/src/artist_model.rs
@@ -1,8 +1,9 @@
 /// Data model for Discogs artist data.
 ///
 /// These structs mirror the structure of an `<artist>` element in the Discogs
-/// artists XML data dump. Used to extract aliases, name variations, and group
-/// membership for enhanced artist filtering.
+/// artists XML data dump. Used to extract aliases, name variations, group
+/// membership, and external URLs for enhanced artist filtering and metadata
+/// enrichment.
 
 #[derive(Debug, Clone, Default)]
 pub struct Artist {
@@ -12,6 +13,7 @@ pub struct Artist {
     pub aliases: Vec<String>,
     pub name_variations: Vec<String>,
     pub members: Vec<Member>,
+    pub urls: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/artist_parser.rs
+++ b/src/artist_parser.rs
@@ -87,6 +87,7 @@ fn parse_artist_body<R: BufRead>(reader: &mut Reader<R>, buf: &mut Vec<u8>) -> R
     let mut in_namevariations = false;
     let mut in_aliases = false;
     let mut in_members = false;
+    let mut in_urls = false;
     let mut current_member_id: u64 = 0;
 
     buf.clear();
@@ -101,6 +102,7 @@ fn parse_artist_body<R: BufRead>(reader: &mut Reader<R>, buf: &mut Vec<u8>) -> R
                     b"namevariations" => in_namevariations = true,
                     b"aliases" => in_aliases = true,
                     b"members" => in_members = true,
+                    b"urls" => in_urls = true,
                     b"name" => {
                         if in_aliases || in_members {
                             // Extract id attribute from <name id="...">
@@ -159,9 +161,18 @@ fn parse_artist_body<R: BufRead>(reader: &mut Reader<R>, buf: &mut Vec<u8>) -> R
                             }
                         }
                     }
+                    b"url" => {
+                        if in_urls {
+                            let text = current_text.trim().to_string();
+                            if !text.is_empty() {
+                                artist.urls.push(text);
+                            }
+                        }
+                    }
                     b"namevariations" => in_namevariations = false,
                     b"aliases" => in_aliases = false,
                     b"members" => in_members = false,
+                    b"urls" => in_urls = false,
                     _ => {}
                 }
 
@@ -271,6 +282,27 @@ mod tests {
         // Nilüfer Yanya has no profile
         let yanya = &artists[1];
         assert!(yanya.profile.is_empty());
+    }
+
+    #[test]
+    fn test_artist_with_urls() {
+        let path = fixture_path("artists_fixture.xml");
+        let mut artists = Vec::new();
+        parse_artists(&path, |a| artists.push(a)).unwrap();
+
+        let sun_ra = &artists[0];
+        assert_eq!(
+            sun_ra.urls,
+            vec![
+                "https://en.wikipedia.org/wiki/Sun_Ra",
+                "https://www.sunraarkestra.com/",
+            ],
+            "empty <url></url> entries must be dropped"
+        );
+
+        // Yanya has no <urls> block — urls is empty.
+        let yanya = &artists[1];
+        assert!(yanya.urls.is_empty());
     }
 
     #[test]

--- a/src/artist_writer.rs
+++ b/src/artist_writer.rs
@@ -1,10 +1,11 @@
 //! CSV output writer for Discogs artist data.
 //!
-//! Writes 4 CSV files:
+//! Writes 5 CSV files:
 //! - artist.csv (artist_id, artist_name, profile)
 //! - artist_alias.csv (artist_id, artist_name, alias_name) — Discogs `<aliases>` (alter egos)
 //! - artist_name_variation.csv (artist_id, name) — Discogs `<namevariations>` (spelling variants)
 //! - artist_member.csv (group_artist_id, group_name, member_artist_id, member_name)
+//! - artist_url.csv (artist_id, url) — Discogs `<urls>` (external links: Wikipedia, official sites, social)
 //!
 //! Aliases and name variations are distinct in Discogs and are stored in
 //! separate tables on the consumer side (`artist_alias` and
@@ -19,12 +20,13 @@ use csv::Writer;
 
 use crate::artist_model::Artist;
 
-/// Manages CSV writers for artist, alias, name-variation, and member output.
+/// Manages CSV writers for artist, alias, name-variation, member, and url output.
 pub struct ArtistCsvOutput {
     artist: Writer<fs::File>,
     alias: Writer<fs::File>,
     name_variation: Writer<fs::File>,
     member: Writer<fs::File>,
+    url: Writer<fs::File>,
 }
 
 impl ArtistCsvOutput {
@@ -54,11 +56,15 @@ impl ArtistCsvOutput {
             "member_name",
         ])?;
 
+        let mut url = Self::create_writer(output_dir, "artist_url.csv")?;
+        url.write_record(["artist_id", "url"])?;
+
         Ok(ArtistCsvOutput {
             artist,
             alias,
             name_variation,
             member,
+            url,
         })
     }
 
@@ -95,6 +101,10 @@ impl ArtistCsvOutput {
             ])?;
         }
 
+        for url in &artist.urls {
+            self.url.write_record([&id_str, url])?;
+        }
+
         Ok(())
     }
 
@@ -104,6 +114,7 @@ impl ArtistCsvOutput {
         self.alias.flush()?;
         self.name_variation.flush()?;
         self.member.flush()?;
+        self.url.flush()?;
         Ok(())
     }
 }
@@ -124,6 +135,10 @@ mod tests {
                 id: 1001,
                 name: "Member One".to_string(),
             }],
+            urls: vec![
+                "https://en.wikipedia.org/wiki/Sean_Combs".to_string(),
+                "https://www.diddy.com/".to_string(),
+            ],
         }
     }
 
@@ -251,6 +266,7 @@ mod tests {
             name_variations: vec!["Solo (var)".to_string()],
             aliases: vec![],
             members: vec![],
+            urls: vec![],
         };
         output.write_artist(&artist).unwrap();
         output.flush().unwrap();
@@ -274,6 +290,52 @@ mod tests {
                 .collect();
         assert_eq!(nvs.len(), 1);
         assert_eq!(&nvs[0][1], "Solo (var)");
+    }
+
+    #[test]
+    fn test_write_artist_urls() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut output = ArtistCsvOutput::new(dir.path()).unwrap();
+        output.write_artist(&sample_artist()).unwrap();
+        output.flush().unwrap();
+
+        let mut rdr = csv::Reader::from_path(dir.path().join("artist_url.csv")).unwrap();
+        let headers: Vec<String> = rdr
+            .headers()
+            .unwrap()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(headers, vec!["artist_id", "url"]);
+
+        let records: Vec<csv::StringRecord> = rdr.records().map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(&records[0][0], "123");
+        assert_eq!(&records[0][1], "https://en.wikipedia.org/wiki/Sean_Combs");
+        assert_eq!(&records[1][0], "123");
+        assert_eq!(&records[1][1], "https://www.diddy.com/");
+    }
+
+    #[test]
+    fn test_skip_empty_urls() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut output = ArtistCsvOutput::new(dir.path()).unwrap();
+        let artist = Artist {
+            id: 42,
+            name: "No URLs".to_string(),
+            urls: vec![],
+            ..Default::default()
+        };
+        output.write_artist(&artist).unwrap();
+        output.flush().unwrap();
+
+        let records: Vec<csv::StringRecord> =
+            csv::Reader::from_path(dir.path().join("artist_url.csv"))
+                .unwrap()
+                .records()
+                .map(|r| r.unwrap())
+                .collect();
+        assert!(records.is_empty());
     }
 
     #[test]

--- a/tests/fixtures/artists_fixture.xml
+++ b/tests/fixtures/artists_fixture.xml
@@ -16,6 +16,11 @@
     <members>
       <name id="1001">Marshall Allen</name>
     </members>
+    <urls>
+      <url>https://en.wikipedia.org/wiki/Sun_Ra</url>
+      <url>https://www.sunraarkestra.com/</url>
+      <url></url>
+    </urls>
   </artist>
   <artist>
     <id>200</id>


### PR DESCRIPTION
## Summary

Discogs's artist XML dump includes a `<urls>` block with external links (Wikipedia, official sites, social platforms). Until now the converter discarded it. This change extracts those URLs and emits an `artist_url.csv` alongside the existing four artist-side CSVs, so the downstream ETL can populate the `artist_url` table during the monthly rebuild.

Three small pieces, all in the artist pipeline:

- **`artist_model.rs`** — `Artist` gains `urls: Vec<String>`.
- **`artist_parser.rs`** — new `in_urls` flag mirrors the existing `in_namevariations` / `in_aliases` / `in_members` gating; non-empty `<url>` text content under `<urls>` is pushed onto `artist.urls`. Empty `<url></url>` entries are dropped at the parser.
- **`artist_writer.rs`** — fifth CSV `artist_url.csv` with header `artist_id,url`. One row per URL per artist, matching the `artist_alias` / `artist_name_variation` row-shape.

This is step 2 of WXYC/library-metadata-lookup#497 (step 1 — `rebuild-cache.sh` fetching `artists.xml.gz` and switching to directory mode — landed in WXYC/discogs-etl#265). The matching `import_csv.py` wiring to load `artist_url.csv` into the `artist_url` table is step 3 and will follow in a discogs-etl PR.

Audit of the 2026-03 artists XML dump (2 GB) confirmed `<urls>` is present with real URLs (Wikipedia, Bandcamp, SoundCloud, Facebook, Twitter, Last.fm, official sites). `<image>` is absent from the dump, so `image_url` stays out of scope and remains a runtime `api_fetch`-only field.

## Test plan

- [x] `cargo test` — all 147 unit + 8 PG-integration tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` on `artist_parser.rs` / `artist_writer.rs` / `artist_model.rs` — clean (pre-existing `assert_eq!(_, true/false)` warnings in `src/parser.rs` are unrelated and predate this branch)
- [x] `cargo build --release` — clean
- [x] New parser test asserts `<url></url>` empty entries are dropped, and that an artist with no `<urls>` block has an empty `urls` vec
- [x] New writer tests assert `artist_url.csv` header and row content; an empty `urls` vec produces zero rows

Refs WXYC/library-metadata-lookup#497